### PR TITLE
Update dat protocol policies to add support for Fetch API, ServiceWorkers, and CORS

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,7 @@
   "productName": "Beaker Browser",
   "description": "The Peer-to-Peer Web Browser.",
   "homepage": "https://beakerbrowser.com/",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "author": "Paul Frazee <pfrazee@gmail.com>",
   "copyright": "© 2016, Paul Frazee",
   "main": "background-process.build.js",

--- a/app/webview-preload.js
+++ b/app/webview-preload.js
@@ -1,6 +1,19 @@
+import { webFrame } from 'electron'
 import importWebAPIs from './lib/fg/import-web-apis'
 import babelBrowserBuild from 'browser-es-module-loader/dist/babel-browser-build'
 import BrowserESModuleLoader from 'browser-es-module-loader/dist/browser-es-module-loader'
+
+// register protocol behaviors
+webFrame.registerURLSchemeAsPrivileged('dat')
+/* This marks the scheme as:
+ - Secure
+ - Bypassing CSP
+ - Allowing Service Workers
+ - Supporting Fetch API
+ - CORS Enabled
+TODO: we dont want to bypass CSP! that will need some electron fixes
+see https://github.com/electron/electron/issues/7430
+*/
 
 // setup UI
 importWebAPIs()


### PR DESCRIPTION
This PR enables Fetch API, Service Workers, and CORS in sites served over dat://. Closes #95. Closes #90.

Makes some progress on https://github.com/beakerbrowser/beaker/issues/46. Still need a way to inject WebAPIs into ServiceWorkers.

There is an open issue, https://github.com/electron/electron/issues/7430. The electron API for enabling these features also enables the dat:// scheme to bypass CSP. Fairly certain we don't want that. Will open a tracking issue on this repo as well.