### PR TITLE
Add live reloading to dats

### DIFF
--- a/app/shell-window/pages.js
+++ b/app/shell-window/pages.js
@@ -120,12 +120,6 @@ export function create (opts) {
       navbar.update(page)
     },
 
-    // start/stop live reloading
-    toggleLiveReloading: function () {
-      page.isLiveReloading = !page.isLiveReloading
-      navbar.update(page)
-    },
-
     getURLOrigin: function () {
       return parseURL(this.getURL()).origin
     },
@@ -141,13 +135,22 @@ export function create (opts) {
       return `beaker:archive/${urlp.host}${path}`
     },
 
+    // start/stop live reloading
+    toggleLiveReloading: function () {
+      page.isLiveReloading = !page.isLiveReloading
+      navbar.update(page)
+    },
+
+    // reload the page due to changes in the dat
     triggerLiveReload: debounce(archiveKey => {
       // double check that we're still on the page
       if (page.isLiveReloading && page.getIntendedURL().startsWith('dat://' + archiveKey)) {
         // reload
         page.reload()
       }
-    }, TRIGGER_LIVE_RELOAD_DEBOUNCE)
+    }, TRIGGER_LIVE_RELOAD_DEBOUNCE, true)
+    // ^ note this is on the front edge of the debouncer.
+    // That means snappier reloads (no delay) but possible double reloads if multiple files change
   }
 
   if (opts.isPinned)

--- a/app/shell-window/pages/live-reload.js
+++ b/app/shell-window/pages/live-reload.js
@@ -1,0 +1,27 @@
+import emitStream from 'emit-stream'
+import * as pages from '../pages'
+
+// exported api
+// =
+
+export function setup () {
+  // wire up events
+  var archivesEvents = emitStream(datInternalAPI.archivesEventStream())
+  archivesEvents.on('update-listing', onUpdateListing)
+}
+
+// event handlers
+// =
+
+function onUpdateListing ({ key }) {
+  // find all pages that are 1) live reloading, and 2) on this archive
+  pages.getAll().forEach(page => {
+    if (page.isLiveReloading && isViewingArchive(page, key)) {
+      page.triggerLiveReload(key)
+    }
+  })
+}
+
+function isViewingArchive (page, archiveKey) {
+  return page.getIntendedURL().startsWith('dat://' + archiveKey)
+}

--- a/app/shell-window/ui.js
+++ b/app/shell-window/ui.js
@@ -3,6 +3,7 @@ import url from 'url'
 import * as tabs from './ui/tabs'
 import * as navbar from './ui/navbar'
 import * as pages from './pages'
+import * as liveReload from './pages/live-reload'
 import * as commandHandlers from './command-handlers'
 import * as swipeHandlers from './swipe-handlers'
 
@@ -28,6 +29,7 @@ export function setup (cb) {
   navbar.setup()
   commandHandlers.setup()
   swipeHandlers.setup()
+  liveReload.setup()
   pages.setActive(pages.create(pages.DEFAULT_URL))
   cb()
 }

--- a/app/shell-window/ui/tabs.js
+++ b/app/shell-window/ui/tabs.js
@@ -369,10 +369,12 @@ function getPageStyle (page) {
   }
 
   // z-index
-  var zIndex = pageIndex // default to the order across
-  if (page.isActive) {
+  var zIndex = pageIndex + 1 // default to the order across
+  if (!pageObject) {
+    zIndex = 0 // the add btn
+  } else if (pageObject.isActive) {
     zIndex = 999 // top
-  } else if (page.isTabDragging) {
+  } else if (pageObject.isTabDragging) {
     zIndex = 998 // almost top
   }
 

--- a/app/stylesheets/shell-window/chrome-tabs.less
+++ b/app/stylesheets/shell-window/chrome-tabs.less
@@ -33,7 +33,7 @@
       bottom: 0;
       left: 0;
       z-index: -1;
-      border: 1px solid #a5a5a5;
+      border: 1px solid #a0a0a0;
       border-top-color: #888;
       border-bottom-color: #aaa;
       background: #ddd;

--- a/app/stylesheets/shell-window/toolbar-dropdown.less
+++ b/app/stylesheets/shell-window/toolbar-dropdown.less
@@ -58,6 +58,9 @@
     .icon {
       display: inline-block;
       width: 16px;
+      &.icon-flash {
+        padding-left: 3px;
+      }
     }
 
     .td-item-name {

--- a/app/stylesheets/shell-window/toolbar-input-group.less
+++ b/app/stylesheets/shell-window/toolbar-input-group.less
@@ -110,6 +110,19 @@
       .icon {
         cursor: pointer;
       }
+
+      &.nav-live-reload-btn {
+        color: gold;
+        padding-right: 0;
+        min-width: 15px;
+        -webkit-text-stroke: 1px #eabb33;
+        animation-name: navLiveReloadBtnGlow;
+        animation-duration: 2s;
+        animation-iteration-count: infinite;
+        .icon {
+          font-size: 14px;
+        }
+      }
     }
   }
 
@@ -168,4 +181,10 @@
       }
     }
   }
+}
+
+@keyframes navLiveReloadBtnGlow {
+  from { text-shadow: 0 0 0 #eabb33; }
+  50% { text-shadow: 0 0 5px #eabb33; }
+  to { text-shadow: 0 0 0 #eabb33; }
 }


### PR DESCRIPTION
[Demo video](https://www.youtube.com/watch?v=xcCNAAo8X8E)

This PR adds a toggleable Live Reloading mode to dat pages. Live reload watches the current page's dat for changes to the the file listing. Any time a file is changed in the dat, the page will refresh.

Note, it currently will reload after a change to *any page* in the dat. That's in case the change was made to, eg, a css file that's embedded in the page.