### PR TITLE
fix: dat archives using dns now correctly load in beaker:archive/

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -8,7 +8,7 @@
   "copyright": "© 2016, Paul Frazee",
   "main": "background-process.build.js",
   "dependencies": {
-    "beaker-plugin-dat": "~6.1.0",
+    "beaker-plugin-dat": "~6.2.0",
     "beaker-plugin-ipfs": "~2.0.1",
     "browser-es-module-loader": "^0.1.6",
     "co": "^4.6.0",


### PR DESCRIPTION
A dat site using DNS, such as `dat://hostless.website`, will now redirect to the archive key when viewing its files.