### PR TITLE
Inject a default background color, to avoid double-renders (close #68)

### DIFF
--- a/app/shell-window/pages.js
+++ b/app/shell-window/pages.js
@@ -521,8 +521,15 @@ function onDidStopLoading (e) {
     // inject some corrections to the user-agent styles
     // real solution is to update electron so we can change the user-agent styles
     // -prf
-    page.webviewEl.insertCSS(`
-      body:-webkit-full-page-media {
+    page.webviewEl.insertCSS(
+      // set the default background to white.
+      // on some devices, if no bg is set, the buffer doesnt get cleared
+      `body {
+        background: #fff;
+      }` +
+
+      // adjust the positioning of fullpage media players
+      `body:-webkit-full-page-media {
         background: #ddd;
       }
       audio:-webkit-full-page-media, video:-webkit-full-page-media {
@@ -530,8 +537,8 @@ function onDidStopLoading (e) {
         top: 50%;
         left: 50%;
         transform: translate(-50%, -50%);
-      }
-    `)
+      }`
+    )
   }
 }
 


### PR DESCRIPTION
This should fix #68. @joehand and @xpollen8, if you experience double rendering after the next release (0.3.7) please re-open #68. I don't experience the bug, so I probably won't notice.