### PR TITLE
Add sublocation API and use to improve archive view

### DIFF
--- a/app/shell-window/ui/navbar.js
+++ b/app/shell-window/ui/navbar.js
@@ -143,7 +143,6 @@ function render (id, page) {
             value=${findValue} />`
     : ''
 
-
   // bookmark toggle state
   var bookmarkClass = 'nav-bookmark-btn' + ((page && !!page.bookmark) ? ' active' : '')
 
@@ -219,8 +218,28 @@ function render (id, page) {
   var addrEl = page && page.navbarEl.querySelector('.nav-location-input')
   var addrValue = addrEl ? addrEl.value : ''
 
+  // the sublocation
+  var sublocationTitle = ''
+  if (page && page.sublocation) {
+    sublocationTitle = yo`<button class="sublocation-title">
+      ${page.sublocation.title}
+    </button>`
+  }
+
   // setup site-perms dropdown
   sitePermsNavbarBtn.protocolDescription = (page && page.protocolDescription)
+
+  // the main URL input
+  var locationInput = yo`
+    <input
+      type="text"
+      class="nav-location-input"
+      onfocus=${onFocusLocation}
+      onblur=${onBlurLocation}
+      onkeydown=${onKeydownLocation}
+      oninput=${onInputLocation}
+      value=${addrValue} />
+  `
 
   // render
   return yo`<div data-id=${id} class="toolbar-actions${toolbarHidden}">
@@ -235,14 +254,8 @@ function render (id, page) {
     </div>
     <div class="toolbar-input-group">
       ${sitePermsNavbarBtn.render()}
-      <input
-        type="text"
-        class="nav-location-input"
-        onfocus=${onFocusLocation}
-        onblur=${onBlurLocation}
-        onkeydown=${onKeydownLocation}
-        oninput=${onInputLocation}
-        value=${addrValue} />
+      ${sublocationTitle}
+      ${locationInput}
       <span class="charms">
         ${liveReloadBtn}
         ${viewDatBtn}
@@ -517,7 +530,7 @@ function onKeydownLocation (e) {
   // on escape
   if (e.keyCode == KEYCODE_ESC) {
     var page = getEventPage(e)
-    page.navbarEl.querySelector('.nav-location-input').value = page.getURL()
+    page.navbarEl.querySelector('.nav-location-input').value = page.getIntendedURL()
     e.target.blur()
     return
   }

--- a/app/stylesheets/shell-window/toolbar-input-group.less
+++ b/app/stylesheets/shell-window/toolbar-input-group.less
@@ -76,7 +76,6 @@
       font-weight: bold;
       color: #333;
       padding: 4px 8px 4px 9px;
-      cursor: pointer;
       border: 0;
       border-right: 1px solid #ccc;
     }

--- a/app/stylesheets/shell-window/toolbar-input-group.less
+++ b/app/stylesheets/shell-window/toolbar-input-group.less
@@ -71,6 +71,16 @@
       }
     }
 
+    &.sublocation-title {
+      font-size: 14px;
+      font-weight: bold;
+      color: #333;
+      padding: 4px 8px 4px 9px;
+      cursor: pointer;
+      border: 0;
+      border-right: 1px solid #ccc;
+    }
+
     &.green {
       color: #555;
       padding: 4px 3px 4px 9px;

--- a/app/webview-preload.js
+++ b/app/webview-preload.js
@@ -1,5 +1,6 @@
 import { webFrame } from 'electron'
 import importWebAPIs from './lib/fg/import-web-apis'
+import { setup as setupLocationbar } from './webview-preload/locationbar'
 import babelBrowserBuild from 'browser-es-module-loader/dist/babel-browser-build'
 import BrowserESModuleLoader from 'browser-es-module-loader/dist/browser-es-module-loader'
 
@@ -15,8 +16,7 @@ TODO: we dont want to bypass CSP! that will need some electron fixes
 see https://github.com/electron/electron/issues/7430
 */
 
-// setup UI
+// setup APIs
 importWebAPIs()
-
-// attach globals
+setupLocationbar()
 window.BrowserESModuleLoader = BrowserESModuleLoader

--- a/app/webview-preload/locationbar.js
+++ b/app/webview-preload/locationbar.js
@@ -1,0 +1,21 @@
+import { ipcRenderer } from 'electron'
+
+// exported api
+// =
+
+export function setup () {
+  // attach sublocation methods
+  // TODO for now, only allow on beaker sites -prf
+  if (window.location.protocol === 'beaker:') {
+    window.locationbar.setSublocation = setSublocation
+    window.locationbar.clearSublocation = clearSublocation
+  }
+}
+
+function setSublocation ({ title, value }) {
+  ipcRenderer.sendToHost('sublocation:set', { title, value })
+}
+
+function clearSublocation () {
+  ipcRenderer.sendToHost('sublocation:clear')
+}


### PR DESCRIPTION
This PR adds `window.locationbar.setSublocation({ title, value })` and `window.sublocation.clearSublociation()`. These APIs are only available to sites served over `beaker:` for now.

The API is used in the builtin archive view to cause the URL bar to look like this:

![screen shot 2016-10-16 at 2 49 51 pm](https://cloud.githubusercontent.com/assets/1270099/19420378/093a1d50-93b0-11e6-9e86-52c9c5d63950.png)

This solves a problem with URLs in the Archive Viewer. The viewer uses a URL scheme of `beaker:archive/{datKey}/{path...}`. We don't want users to share that URL - rather, we want them to share `dat://{datKey}/{path...}`.

This API solves that issue by showing the URL we intend to show. It, in a way, treats the Archive Viewer as a "browser within the browser." Thus, if the location is the archive viewer, then the sublocation is the the dat itself.

In the future, this might be generalized and made available for dat applications. For now, it's just going to be used by the builtin pages.