### PR TITLE
Custom Electron Build (which introduces fix for #94)

### DIFF
--- a/app/shell-window/pages.js
+++ b/app/shell-window/pages.js
@@ -682,6 +682,7 @@ function createWebviewEl (id, url) {
   var el = document.createElement('webview')
   el.dataset.id = id
   el.setAttribute('preload', 'file://'+path.join(remote.app.getAppPath(), 'webview-preload.build.js'))
+  el.setAttribute('webpreferences', 'allowDisplayingInsecureContent')
   el.setAttribute('src', url || DEFAULT_URL)
   return el
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "browserify": "^13.0.1",
     "chai": "^3.5.0",
     "electron-builder": "~5.30.0",
-    "electron": "1.4.1",
+    "electron": "beakerbrowser/electron-prebuilt",
     "fs-jetpack": "^0.9.0",
     "gulp": "^3.9.0",
     "gulp-batch": "^1.0.5",
@@ -59,7 +59,7 @@
   "scripts": {
     "postinstall": "cd app && npm install",
     "build": "gulp build",
-    "rebuild": "(cd app && npm rebuild --runtime=electron --target=1.4.1 --disturl=https://atom.io/download/atom-shell --build-from-source); gulp build",
+    "rebuild": "(cd app && npm rebuild --runtime=electron --target=1.4.3 --disturl=https://atom.io/download/atom-shell --build-from-source); gulp build",
     "burnthemall": "rm -Rf ./node_modules ./app/node_modules; npm i",
     "release": "build -m -p never",
     "start": "gulp start",


### PR DESCRIPTION
This PR switches beaker to a custom build of Electron, which is located at https://github.com/beakerbrowser/electron

This incorporates a fix for #94 which will hopefully make its way into the main electron soon.