### PR TITLE
Fixes to dat swarming

### DIFF
--- a/app/background-process/networks/dat/dat.js
+++ b/app/background-process/networks/dat/dat.js
@@ -364,7 +364,6 @@ export function swarm (key, opts) {
   // massage inputs
   key = bufToStr(key.key || key)
   opts = { upload: (opts && opts.upload), download: true, utp: true, tcp: true }
-  console.log('swarming', key, opts.upload)
 
   // fetch
   if (key in swarms) {
@@ -374,7 +373,6 @@ export function swarm (key, opts) {
     if (s.uploading === opts.upload) return s
 
     // reswarm
-    console.log('unswarming first')
     unswarm(key, () => swarm(key, opts))
     return
   }

--- a/app/background-process/networks/dat/dat.js
+++ b/app/background-process/networks/dat/dat.js
@@ -364,6 +364,7 @@ export function swarm (key, opts) {
   // massage inputs
   key = bufToStr(key.key || key)
   opts = { upload: (opts && opts.upload), download: true, utp: true, tcp: true }
+  console.log('swarming', key, opts.upload)
 
   // fetch
   if (key in swarms) {
@@ -373,6 +374,7 @@ export function swarm (key, opts) {
     if (s.uploading === opts.upload) return s
 
     // reswarm
+    console.log('unswarming first')
     unswarm(key, () => swarm(key, opts))
     return
   }
@@ -394,7 +396,11 @@ export function swarm (key, opts) {
 export function unswarm (key, cb) {
   key = bufToStr(key)
   var s = swarms[key]
-  if (!s || s.isClosing) return cb()
+  if (!s) return cb()
+  if (s.isClosing) {
+    if (cb) s.on('close', cb)
+    return
+  }
   s.isClosing = true
   s.leave(getArchive(key).discoveryKey)
   s.close(() => {

--- a/app/background-process/networks/dat/web-api.js
+++ b/app/background-process/networks/dat/web-api.js
@@ -335,9 +335,6 @@ function lookupArchive (url) {
 
   // lookup the archive
   var archive = dat.getArchive(archiveKey)
-  if (!archive) {
-    archive = dat.loadArchive(new Buffer(archiveKey, 'hex'))
-    dat.swarm(archiveKey)
-  }
+  if (!archive) archive = dat.loadArchive(new Buffer(archiveKey, 'hex'))
   return { archive, filepath }
 }

--- a/app/builtin-pages/views/archive.js
+++ b/app/builtin-pages/views/archive.js
@@ -484,52 +484,55 @@ function addFiles (files) {
 
 function onToggleSave () {
   // toggle the save
-  datInternalAPI.updateArchiveClaims(archiveInfo.key, {
-    origin: 'beaker:archives', 
-    op: 'toggle-all', 
-    claims: 'save'
-  }).then(settings => {
-    archiveInfo.userSettings.saveClaims = settings.saveClaims
-    render()
-
-    // auto-unnetwork if deleted
-    if (!isSaved(archiveInfo) && isNetworked(archiveInfo)) {
-      datInternalAPI.updateArchiveClaims(archiveInfo.key, {
-        origin: 'beaker:archives', 
-        op: 'remove-all', 
-        claims: ['upload', 'download']
-      }).then(settings => {
-        archiveInfo.userSettings.uploadClaims = settings.uploadClaims
-        archiveInfo.userSettings.downloadClaims = settings.downloadClaims
-        render()
-      })
-    }
-  })
+  if (isSaved(archiveInfo)) {
+    datInternalAPI.updateArchiveClaims(archiveInfo.key, {
+      origin: 'beaker:archives', 
+      op: 'remove-all', 
+      claims: ['save', 'upload', 'download']
+    }).then(settings => {
+      archiveInfo.userSettings.saveClaims = settings.saveClaims
+      archiveInfo.userSettings.uploadClaims = settings.uploadClaims
+      archiveInfo.userSettings.downloadClaims = settings.downloadClaims
+      render()
+    })
+  } else {
+    datInternalAPI.updateArchiveClaims(archiveInfo.key, {
+      origin: 'beaker:archives', 
+      op: 'add', 
+      claims: 'save'
+    }).then(settings => {
+      archiveInfo.userSettings.saveClaims = settings.saveClaims
+      render()
+    })
+  }
 }
 
 function onToggleServing () {
   // toggle the networking
-  datInternalAPI.updateArchiveClaims(archiveInfo.key, {
-    origin: 'beaker:archives',
-    op: (isNetworked(archiveInfo)) ? 'remove-all' : 'add',
-    claims: ['upload', 'download']
-  }).then(settings => {
-    archiveInfo.userSettings.uploadClaims = settings.uploadClaims
-    archiveInfo.userSettings.downloadClaims = settings.downloadClaims
-    render()
-
-    // autosave if networked, but not saved
-    if (isNetworked(archiveInfo) && !isSaved(archiveInfo)) {
-      datInternalAPI.updateArchiveClaims(archiveInfo.key, {
-        origin: 'beaker:archives',
-        op: 'add',
-        claims: 'save'
-      }).then(settings => {
-        archiveInfo.userSettings.saveClaims = settings.saveClaims
-        render()
-      })
-    }
-  })
+  if (isNetworked(archiveInfo)) {
+    datInternalAPI.updateArchiveClaims(archiveInfo.key, {
+      origin: 'beaker:archives',
+      op: 'remove-all',
+      claims: ['upload', 'download']
+    }).then(settings => {
+      archiveInfo.userSettings.uploadClaims = settings.uploadClaims
+      archiveInfo.userSettings.downloadClaims = settings.downloadClaims
+      render()
+    })
+  } else {
+    var claims = ['upload', 'download']
+    if (!isSaved(archiveInfo)) claims.push('save')
+    datInternalAPI.updateArchiveClaims(archiveInfo.key, {
+      origin: 'beaker:archives', 
+      op: 'add', 
+      claims
+    }).then(settings => {
+      archiveInfo.userSettings.saveClaims = settings.saveClaims
+      archiveInfo.userSettings.uploadClaims = settings.uploadClaims
+      archiveInfo.userSettings.downloadClaims = settings.downloadClaims
+      render()
+    })
+  }
 }
 
 function onOpenFolder (e, entry) {

--- a/app/lib/fg/import-web-apis.js
+++ b/app/lib/fg/import-web-apis.js
@@ -8,6 +8,6 @@ const BEAKER_VERSION = '0.0.1'
 export default function () {
   var webAPIs = ipcRenderer.sendSync('get-web-api-manifests', window.location.protocol)
   for (var k in webAPIs) {
-    window[k] = rpc.importAPI(k, webAPIs[k], { timeout: false })
+    window[k] = rpc.importAPI(k, webAPIs[k], { timeout: false, noEval: (window.location.protocol === 'beaker:') })
   }
 }

--- a/app/package.json
+++ b/app/package.json
@@ -22,7 +22,7 @@
     "get-folder-size": "^1.0.0",
     "global-modules": "^0.2.3",
     "hyperdrive": "^7.7.1",
-    "hyperdrive-archive-swarm": "^4.1.6",
+    "hyperdrive-archive-swarm": "^5.0.2",
     "hyperdrive-import-files": "^2.3.0",
     "identify-filetype": "^1.0.0",
     "level": "^1.5.0",


### PR DESCRIPTION
There were some cases where dats where not getting swarmed correctly. This PR fixes them, mainly by dropping out of the swarm and rejoining when the `upload` config toggles between true/false.