### PR TITLE
change tab traverse hotkey to be consistent with other major browsers

### DIFF
--- a/app/background-process/ui/window-menu.js
+++ b/app/background-process/ui/window-menu.js
@@ -180,14 +180,14 @@ var windowMenu = {
     },
     {
       label: 'Next Tab',
-      accelerator: 'CmdOrCtrl+]',
+      accelerator: 'CmdOrCtrl+}',
       click: function (item, win) {
         if (win) win.webContents.send('command', 'window:next-tab')
       }
     },
     {
       label: 'Previous Tab',
-      accelerator: 'CmdOrCtrl+[',
+      accelerator: 'CmdOrCtrl+{',
       click: function (item, win) {
         if (win) win.webContents.send('command', 'window:prev-tab')
       }


### PR DESCRIPTION
All major browsers (Chrome/Safari/Firefox) use `cmd+{` and `cmd+}` as the hotkey to go to next/previous tab.

We should use the same hotkey for accessibility.