### PR TITLE
Tests requires bkr v1.1.0, bump version

### DIFF
--- a/tests/package.json
+++ b/tests/package.json
@@ -6,7 +6,7 @@
   "optionalDependencies": {},
   "dependencies": {
     "ava": "^0.16.0",
-    "bkr": "~1.0.0",
+    "bkr": "~1.1.0",
     "dat-js": "^3.6.0",
     "memdb": "^1.3.1",
     "spectron": "^3.4.0"


### PR DESCRIPTION
Tests will fail if `bkr` 1.0 is installed before. `npm install` won't fix it. Requires manual upgrade.
```
   1. bkr-test › bkr init
   failed with "Command failed: /Users/poga/projects/beaker/tests/node_modules/bkr/build/bin/bkr init /var/folders/8m/93jxmmg550qcwp5ddm7zb7s00000gn/T/beaker-test-WsrZOC
Bkr version is 1 and minimum required is 1.1.0. Can you update bkr?
"
      Bkr version is 1 and minimum required is 1.1.0. Can you update bkr?
        ChildProcess.exithandler (child_process.js:211:12)
```

set the minimum required version should avoid further confusion.