### PR TITLE
select navbar content even when it's already focused

### DIFF
--- a/app/shell-window/ui/navbar.js
+++ b/app/shell-window/ui/navbar.js
@@ -50,6 +50,7 @@ export function createEl (id) {
 export function focusLocation (page) {
   var el = page.navbarEl.querySelector('.nav-location-input')
   el.focus()
+  el.select()
 }
 
 export function showInpageFind (page) {


### PR DESCRIPTION
This PR makes the <kbd>CmdOrCtrl</kbd><kbd>l</kbd> shortcut select the contents of the address/location/nav/wonder/omni bar, even if it's already focused. This behavior is consistent with Chrome, Firefox, and Safari.

Please let me know if this should have a test somewhere!

![beaker-select](https://cloud.githubusercontent.com/assets/2289/21570067/6f408dc6-ce77-11e6-87dc-7725b6a733f5.gif)
