### PR TITLE
Restyle the beaker:archives page to a grid layout

### DIFF
--- a/app/stylesheets/com/archives.less
+++ b/app/stylesheets/com/archives.less
@@ -1,8 +1,20 @@
 .archives-list {
+  display: flex;
+  flex-wrap: wrap;
   font-size: 15px;
+
+  .notice {
+    flex: 1 0 100%;
+  }
+
   .al-row {
-    padding: 20px 10px;
-    border-top: 1px solid #ddd;
+    flex: 1 0 100%;
+    max-width: 440px;
+    background: #fdfdfd;
+    border: 1px solid #ddd;
+    border-radius: 3px;
+    padding: 6px 10px 20px;
+    margin: 10px 10px 0px 0;
 
     .al-main {
       display: flex;


### PR DESCRIPTION
![screen shot 2017-01-01 at 2 06 51 pm](https://cloud.githubusercontent.com/assets/1270099/21582782/dfd773be-d02b-11e6-9d01-5321a7949a42.png)

Makes a little better use of the space.