### PR TITLE
Render hashes in the URL bar with pretty-hash, and gray the path

### DIFF
--- a/app/stylesheets/shell-window/toolbar-input-group.less
+++ b/app/stylesheets/shell-window/toolbar-input-group.less
@@ -109,6 +109,16 @@
     }
   }
 
+  .nav-location-pretty {
+    flex: 1;
+    padding: 3px 0 1px 7px;
+    cursor: text;
+
+    .path {
+      color: #aaa;
+    }
+  }
+
   .charms {
     padding: 0px 5px;
     button {


### PR DESCRIPTION
Closes https://github.com/beakerbrowser/beaker/issues/229

![screen shot 2017-01-01 at 4 05 38 pm](https://cloud.githubusercontent.com/assets/1270099/21583215/6f7c3850-d03c-11e6-9e86-a02d54d0fe23.png)

@zeke I decided to keep the shortened hash as-is, for now, so that it's very clear that a truncation is happening