### PR TITLE
proof of concept: add support for ctrl - mousewheel zoomIn/Out

### DIFF
--- a/app/shell-window/swipe-handlers.js
+++ b/app/shell-window/swipe-handlers.js
@@ -1,5 +1,6 @@
 import { ipcRenderer } from 'electron'
 import * as pages from './pages'
+import * as zoom from './pages/zoom'
 
 var SWIPE_TRIGGER_DIST = 400 // how far do you need to travel to trigger the navigation
 var ARROW_OFF_DIST = 80 // how far off-screen are the arrows
@@ -28,6 +29,14 @@ export function setup () {
   }
 
   window.addEventListener('mousewheel', e => {
+
+    // TODO add key for macOS
+    if (e.ctrlKey === true) {
+      var page = pages.getActive()
+      if (e.deltaY > 0) zoom.zoomOut(page)
+      if (e.deltaY < 0) zoom.zoomIn(page)
+    }
+
     if (isTouching) {
 
       // track amount of x & y traveled


### PR DESCRIPTION
As proposed in #254  add support for ctrl - mousewheel zoomIn/Out for ubuntu 16.10, should also work with windows. 

but .. need more info for mac. 