### PR TITLE
Dat network bugfixing

### DIFF
--- a/app/background-process.js
+++ b/app/background-process.js
@@ -1,3 +1,5 @@
+Error.stackTraceLimit = Infinity;
+
 // This is main process of Electron, started as first thing when your
 // app starts. This script is running through entire life of your application.
 // It doesn't have any windows which you can see on screen, but we can open

--- a/app/background-process/networks/dat/dat.js
+++ b/app/background-process/networks/dat/dat.js
@@ -229,6 +229,7 @@ export function loadArchive (key, { noSwarm } = {}) {
   var archive = drive.createArchive(key, {
     live: true,
     sparse: true,
+    verifyReplicationReads: true,
     file: name => raf(path.join(archivesDb.getArchiveFilesPath(archive), name))
   })
   archive.userSettings = null // will be set by `configureArchive` if at all

--- a/app/background-process/networks/dat/dat.js
+++ b/app/background-process/networks/dat/dat.js
@@ -255,6 +255,10 @@ export function getArchive (key) {
   return archives[bufToStr(key)]
 }
 
+export function getActiveArchives () {
+  return archives
+}
+
 export function getOrLoadArchive (key, opts) {
   key = bufToStr(key)
   return getArchive(key) || loadArchive(new Buffer(key, 'hex'), opts)

--- a/app/background-process/networks/dat/dat.js
+++ b/app/background-process/networks/dat/dat.js
@@ -510,7 +510,7 @@ export function joinSwarm (key, opts) {
         debug('handshake timeout chan=%s type=%s host=%s key=%s', chan, info.type, info.host, keyStrShort)
         stream.destroy(new Error('Timed out waiting for handshake'))
       }, 5000)
-      stream.once('open', () => clearTimeout(TO))
+      stream.once('handshake', () => clearTimeout(TO))
 
       // debugging
       stream.on('error', err => debug('error chan=%s type=%s host=%s key=%s', chan, info.type, info.host, keyStrShort, err))

--- a/app/background-process/networks/dat/debugging.js
+++ b/app/background-process/networks/dat/debugging.js
@@ -1,0 +1,21 @@
+import {getActiveArchives} from './dat'
+
+export function archivesDebugPage () {
+  var archives = getActiveArchives()
+  return `<html>
+    <body>
+      ${Object.keys(archives).map(key => {
+        var a = archives[key]
+        return `<div style="font-family: monospace">
+          <h3>${a.key.toString('hex')}</h3>
+          <table>
+            <tr><td>Meta DKey</td><td>${a.discoveryKey.toString('hex')}</td></tr>
+            <tr><td>Content DKey</td><td>${a.content.discoveryKey.toString('hex')}</td></tr>
+            <tr><td>Meta Key</td><td>${a.key.toString('hex')}</td></tr>
+            <tr><td>Content Key</td><td>${a.content.key.toString('hex')}</td></tr>
+          </table>
+        </div>`
+      }).join('')}
+    </body>
+  </html>`
+}

--- a/app/background-process/protocols/beaker.js
+++ b/app/background-process/protocols/beaker.js
@@ -7,6 +7,7 @@ import http from 'http'
 import crypto from 'crypto'
 import listenRandomPort from 'listen-random-port'
 import errorPage from '../../lib/error-page'
+import {archivesDebugPage} from '../networks/dat/debugging'
 
 // constants
 // =
@@ -61,8 +62,10 @@ function beakerServer (req, res) {
       'Content-Security-Policy': BEAKER_CSP,
       'Access-Control-Allow-Origin': '*'
     })
-    if (path) {
+    if (typeof path === 'string') {
       fs.createReadStream(path).pipe(res)
+    } else if (typeof path === 'function') {
+      res.end(path())
     } else {
       res.end(errorPage(code + ' ' + status))
     }
@@ -117,6 +120,11 @@ function beakerServer (req, res) {
   }
   if (requestUrl.startsWith('beaker:logo')) {
     return cb(200, 'OK', 'image/png', path.join(__dirname, 'assets/img/logo.png'))
+  }
+
+  // debugging
+  if (requestUrl === 'beaker:internal-archives') {
+    return cb(200, 'OK', 'text/html', archivesDebugPage)
   }
 
   return cb(404, 'Not Found')

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "burnthemall": "rm -Rf ./node_modules ./app/node_modules; npm i; npm run rebuild",
     "release": "build -m -p never",
     "start": "gulp start",
-    "start-p2p-log": "DEBUG_FD=3 DEBUG=bittorrent-dht $(node -e \"console.log(require('electron'))\") ./app 3> p2p.log",
+    "start-logging": "DEBUG=*,-bittorrent-dht $(node -e \"console.log(require('electron'))\") -r trace ./app",
     "watch": "gulp start-watch"
   }
 }


### PR DESCRIPTION
This PR:

 - Enables read-verification during replication, solving a bug which would cause archives to fail to make progress in the network. (Big fix!)
 - Improves logging (debugging)
 - Adds the `beaker:internal-archives` site, so that you can quickly check the active archives and their various keys. (debugging)