### PR TITLE
Get your (dat) priorities straight

### DIFF
--- a/app/background-process/networks/dat/dat.js
+++ b/app/background-process/networks/dat/dat.js
@@ -197,9 +197,6 @@ export function configureArchive (key, settings) {
   archivesEvents.emit('update-archive', { key, isUploading: upload, isDownloading: download })
 
   archive.open(() => {
-    // set download prioritization
-    if (download) archive.content.prioritize({start: 0, end: Infinity}) // autodownload all content
-    else archive.content.unprioritize({start: 0, end: Infinity}) // download content on demand
     if (!archive.isSwarming) {
       // announce
       joinSwarm(archive)

--- a/app/background-process/networks/dat/helpers.js
+++ b/app/background-process/networks/dat/helpers.js
@@ -125,27 +125,13 @@ export function readArchiveFile (archive, name, opts, cb) {
 
 export function readManifest (archive, cb) {
   readArchiveFile(archive, DAT_MANIFEST_FILENAME, (err, data) => {
-    if (data)
-      return done(data)
-
-    // TEMPORARY try legacy (remove in, like, a year. maybe less.)
-    readArchiveFile(archive, 'manifest.json', (err, data) => {
-      if (data)
-        return done(data)
-
-      // no manifest
-      cb()
-    })
+    var manifest = null
+    if (data) {
+      try { manifest = JSON.parse(data.toString()) }
+      catch (e) {}
+    }
+    cb(null, manifest)
   })
-
-  function done (data) {
-    // parse manifest
-    try {
-      var manifest = JSON.parse(data.toString())
-      if (manifest.name || !manifest.title) manifest.title = manifest.name // TEMPORARY legacy fix
-      cb(null, manifest)
-    } catch (e) { cb() }
-  }
 }
 
 export function readReadme (archive, cb) {


### PR DESCRIPTION
Do not auto-download the content of feeds.

This is part of a rather nuanced decision about how to use Dat.
Chiefly: unless the full history of the archive is retained via
external storage, you cannot prioritize the download of the full
content-feed.

Why? It's, in fact, somewhat obvious if you think about it: if
you aren't intent on storing the full history, and your external
storage doesn't properly give each historical version a unique
name, then you are going to end up writing new and old copies of
entries onto the same file as their pieces arrive.

So we must be much more specific about which blocks we request,
unless we intend to store the history, which we don't yet intend
to do.

The solution is simple enough: only download the files on-demand.
We'll add facilities for downloading *all* files in an archive
at some point later.