### PR TITLE
focus the webview after the dom-ready event

### DIFF
--- a/app/shell-window/pages.js
+++ b/app/shell-window/pages.js
@@ -451,6 +451,7 @@ function onDomReady (e) {
   var page = getByWebview(e.target)
   if (page) {
     page.isWebviewReady = true
+    page.webviewEl.focus()
     zoom.setZoomFromSitedata(page)
   }
 }


### PR DESCRIPTION
This focuses the webview after the dom-ready event fires, which fixes
a bug where inputs with the autofocus attribute would not focus unless
the webview was already focused.

Fixes #261