### PR TITLE
Improve dat load times

### DIFF
--- a/app/background-process/protocols/dat.js
+++ b/app/background-process/protocols/dat.js
@@ -219,6 +219,12 @@ function datServer (req, res) {
         // still serving?
         if (aborted) return cleanup()
 
+        // caching if-match
+        const ETag = 'block-' + entry.content.blockOffset
+        if (req.headers['if-none-match'] === ETag) {
+          return cb(304, 'Not Modified')
+        }
+
         // not found
         if (!entry) {
           debug('Entry not found:', urlp.path)
@@ -253,7 +259,9 @@ function datServer (req, res) {
               var headers = {
                 'Content-Type': mimeType,
                 'Content-Security-Policy': CUSTOM_DAT_CSP(origins),
-                'Access-Control-Allow-Origin': '*'
+                'Access-Control-Allow-Origin': '*',
+                'Cache-Control': 'public, max-age: 60',
+                ETag
               }
               if (entry.length) headers['Content-Length'] = entry.length
               res.writeHead(200, 'OK', headers)

--- a/app/webview-preload.js
+++ b/app/webview-preload.js
@@ -2,8 +2,6 @@ import { webFrame } from 'electron'
 import importWebAPIs from './lib/fg/import-web-apis'
 import { setup as setupLocationbar } from './webview-preload/locationbar'
 import { setup as setupNavigatorPermissions } from './webview-preload/navigator-permissions-api'
-import babelBrowserBuild from 'browser-es-module-loader/dist/babel-browser-build'
-import BrowserESModuleLoader from 'browser-es-module-loader/dist/browser-es-module-loader'
 
 // register protocol behaviors
 /* This marks the scheme as:
@@ -18,4 +16,3 @@ webFrame.registerURLSchemeAsPrivileged('dat', { bypassCSP: false })
 importWebAPIs()
 setupLocationbar()
 setupNavigatorPermissions()
-window.BrowserESModuleLoader = BrowserESModuleLoader

--- a/tasks/build/build.js
+++ b/tasks/build/build.js
@@ -45,7 +45,7 @@ gulp.task('burnthemall-maybe', burnthemallMaybeTask)
 var bundleApplication = function () {
   return Q.all([
     bundle(srcDir.path('background-process.js'), srcDir.path('background-process.build.js')),
-    bundle(srcDir.path('webview-preload.js'), srcDir.path('webview-preload.build.js')),
+    bundle(srcDir.path('webview-preload.js'), srcDir.path('webview-preload.build.js'), { browserify: true, basedir: srcDir.cwd(), excludeNodeModules: true }),
     bundle(srcDir.path('shell-window.js'), srcDir.path('shell-window.build.js'), { browserify: true, basedir: srcDir.cwd(), excludeNodeModules: true }),
     bundle(srcDir.path('builtin-pages/downloads.js'), srcDir.path('builtin-pages/downloads.build.js'), { browserify: true, basedir: srcDir.path('builtin-pages') }),
     bundle(srcDir.path('builtin-pages/library.js'), srcDir.path('builtin-pages/library.build.js'), { browserify: true, basedir: srcDir.path('builtin-pages') }),


### PR DESCRIPTION
Two speed improvements:

 1. Use HTTP caching headers in the dat protocol
 2. Avoid any runtime require() calls in the webview-preload by browserifying (big improvement), ~400-500ms.

There's still about 200ms getting lost somewhere, and I'm not sure where. Probably something about electron's webview behaviors. Removing the preload script doesn't get it all.