### PR TITLE
Add builtin markdown rendering (on .md pages)

### DIFF
--- a/app/markdown-renderer.js
+++ b/app/markdown-renderer.js
@@ -1,0 +1,53 @@
+import Remarkable from 'remarkable'
+
+var md = new Remarkable({
+  html:         false,        // Enable HTML tags in source
+  xhtmlOut:     false,        // Use '/' to close single tags (<br />)
+  breaks:       true,         // Convert '\n' in paragraphs into <br>
+  langPrefix:   'language-',  // CSS language prefix for fenced blocks
+  linkify:      true,         // Autoconvert URL-like text to links
+
+  // Enable some language-neutral replacement + quotes beautification
+  typographer:  true,
+
+  // Double + single quotes replacement pairs, when typographer enabled,
+  // and smartquotes on. Set doubles to '«»' for Russian, '„“' for German.
+  quotes: '“”‘’',
+
+  // Highlighter function. Should return escaped HTML,
+  // or '' if the source string is not changed
+  highlight: function (/*str, lang*/) { return ''; }
+});
+
+// hide unformatted el
+var unformattedEl = document.querySelector('body > pre')
+unformattedEl.style.display = 'none'
+
+// show formatted el
+var formattedEl = document.createElement('div')
+formattedEl.style.fontFamily = '-apple-system, BlinkMacSystemFont, "Segoe UI", Ubuntu, Cantarell, "Oxygen Sans", "Helvetica Neue", sans-serif'
+formattedEl.style.margin = '1em'
+formattedEl.innerHTML = md.render(unformattedEl.textContent)
+document.body.appendChild(formattedEl)
+
+// give ui to switch
+var a = document.createElement('a')
+a.setAttribute('href', '#')
+a.style.position = 'absolute'
+a.style.top = '5px'
+a.style.right = '5px'
+a.textContent = 'Raw'
+a.onclick = (e) => {
+  e.preventDefault()
+
+  if (unformattedEl.style.display === 'none') {
+    formattedEl.style.display = 'none'
+    unformattedEl.style.display = 'block'
+    a.textContent = 'Formatted'
+  } else {
+    formattedEl.style.display = 'block'
+    unformattedEl.style.display = 'none'
+    a.textContent = 'Raw'
+  }
+}
+document.body.appendChild(a)

--- a/tasks/build/build.js
+++ b/tasks/build/build.js
@@ -48,6 +48,7 @@ var bundleApplication = function () {
     bundle(srcDir.path('background-process.js'),  srcDir.path('background-process.build.js')),
     bundle(srcDir.path('webview-preload.js'),     srcDir.path('webview-preload.build.js'), { browserify: true, basedir: srcDir.cwd() }),
     bundle(srcDir.path('shell-window.js'),        srcDir.path('shell-window.build.js'), { browserify: true, basedir: srcDir.cwd(), excludeNodeModules: true }),
+    bundle(srcDir.path('markdown-renderer.js'),   srcDir.path('markdown-renderer.build.js'), { browserify: true, basedir: srcDir.cwd(), excludeNodeModules: true }),
     bundle(bpDir.path('downloads.js'),            bpDir.path('downloads.build.js'), { browserify: true, basedir: bpDir.cwd() }),
     bundle(bpDir.path('library.js'),              bpDir.path('library.build.js'), { browserify: true, basedir: bpDir.cwd() }),
     bundle(bpDir.path('bookmarks.js'),            bpDir.path('bookmarks.build.js'), { browserify: true, basedir: bpDir.cwd() }),


### PR DESCRIPTION
Watches for pages loaded that have type 'text/x-markdown' and injects a renderer.