### PR TITLE
Dont accidentally trigger navigations when horizontally scrolling.

### DIFF
--- a/app/background-process/ui/windows.js
+++ b/app/background-process/ui/windows.js
@@ -59,7 +59,7 @@ export function createShellWindow () {
   registerShortcut(win, 'CmdOrCtrl+]', onGoForward(win))
 
   // register event handlers
-  win.on('scroll-touch-begin', sendToWebContents('scroll-touch-begin'))
+  win.on('scroll-touch-begin', sendScrollTouchBegin)
   win.on('scroll-touch-end', sendToWebContents('scroll-touch-end'))
   win.on('focus', sendToWebContents('focus'))
   win.on('blur', sendToWebContents('blur'))
@@ -184,4 +184,15 @@ function onGoForward (win) {
 
 function sendToWebContents (event) {
   return e => e.sender.webContents.send('window-event', event)
+}
+
+function sendScrollTouchBegin(e) {
+  // get the cursor x/y within the window
+  var cursorPos = screen.getCursorScreenPoint()
+  var winPos = e.sender.getBounds()
+  cursorPos.x -= winPos.x; cursorPos.y -= winPos.y
+  e.sender.webContents.send('window-event', 'scroll-touch-begin', {
+    cursorX: cursorPos.x,
+    cursorY: cursorPos.y
+  })
 }

--- a/app/shell-window/swipe-handlers.js
+++ b/app/shell-window/swipe-handlers.js
@@ -73,11 +73,32 @@ export function setup () {
   // for various humorous reasons, the 'scroll-touch-end' event is emitted in the background process
   // so, listen for it over ipc
   // https://github.com/electron/electron/pull/4181
-  ipcRenderer.on('window-event', function (event, type) {
+  ipcRenderer.on('window-event', async function (event, type, data) {
     if (type == 'scroll-touch-begin') {
       leftSwipeArrowEl.classList.remove('returning')
       rightSwipeArrowEl.classList.remove('returning')
-      isTouching = true
+
+      // check if the item under the cursor is scrolling
+      var page = pages.getActive()
+      if (!page) return
+      page.webviewEl.executeJavaScript(`
+        (function() {
+          var isScrolling = false
+          // check if the element under the cursor, or any of its parents, are scrolling horizontally right now
+          var el = document.elementFromPoint(${data.cursorX}, ${data.cursorY})
+          while (el) {
+            if (el.scrollWidth > el.clientWidth) {
+              isScrolling = true
+              break
+            }
+            el = el.parentNode
+          }
+          return isScrolling
+        })()
+      `, true, (isScrollingEl) => {
+        if (isScrollingEl) return // dont do anything
+        isTouching = true
+      })
     }
 
     if (type == 'scroll-touch-end' && isTouching) {


### PR DESCRIPTION
This commit turns off swipe navigations when the user's cursor is
positioned over an element that has horizontal scrolling active.