### PR TITLE
Builtin toasts

### DIFF
--- a/app/builtin-pages/com/editor-header.js
+++ b/app/builtin-pages/com/editor-header.js
@@ -1,6 +1,7 @@
 import * as yo from 'yo-yo'
 import mime from 'mime'
 import * as sharePopup from './editor-share-popup'
+import * as toast from './toast'
 import renderDropdownMenuBar from './dropdown-menu-bar'
 import {niceDate} from '../../lib/time'
 import {writeToClipboard} from '../../lib/fg/event-handlers'
@@ -97,7 +98,10 @@ function rMenu (archive, path, isEditable) {
         '-',
         {label: 'View site', click: () => window.open(archive.url)},
         {label: 'View current file', disabled: isUnsavedFile, click: () => window.open(archive.url + '/' + path)},
-        {label: 'Copy URL', click: () => writeToClipboard(archive.url)}
+        {label: 'Copy URL', click: () => {
+          writeToClipboard(archive.url)
+          toast.create(`URL for ${archive.info.title} copied to clipboard.`)
+        }}
       ]
     },
     {
@@ -198,6 +202,7 @@ async function onFork (archive) {
 async function onSave (archive) {
   closeAllToggleables()
   await beaker.archives.add(archive.url)
+  toast.create(`Saved ${archive.info.title} to your library.`)
   archive.info.userSettings.isSaved = true
   window.dispatchEvent(new Event('render'))
 }
@@ -205,6 +210,7 @@ async function onSave (archive) {
 async function onDelete (archive) {
   closeAllToggleables()
   await beaker.archives.remove(archive.url)
+  toast.create(`Removed ${archive.info.title} from your library.`)
   archive.info.userSettings.isSaved = false
   window.dispatchEvent(new Event('render'))
 }

--- a/app/builtin-pages/com/toast.js
+++ b/app/builtin-pages/com/toast.js
@@ -1,0 +1,24 @@
+import yo from 'yo-yo'
+
+function render (message) {
+  return yo`
+    <div id="toast-wrapper" class="toast-wrapper">
+      <p class="toast">${message}</p>
+    </div>
+  `
+}
+
+export function create (message) {
+  // render toast
+  var toast = render(message)
+  document.body.appendChild(toast)
+  setTimeout(destroy, 1500);
+}
+
+function destroy () {
+  var toast = document.getElementById('toast-wrapper')
+
+  // fadeout before removing element
+  toast.classList.add('hidden')
+  setTimeout(() => document.body.removeChild(toast), 500)
+}

--- a/app/builtin-pages/views/editor.js
+++ b/app/builtin-pages/views/editor.js
@@ -7,6 +7,7 @@ import {render as renderFileView} from '../com/editor-file-view'
 import {update as updateHeader} from '../com/editor-header'
 import setupContextMenu from '../com/editor-context-menu'
 import * as choosePathPopup from '../com/editor-choose-path-popup'
+import * as toast from '../com/toast'
 import defineTheme from '../com/monaco-theme'
 import {pushUrl} from '../../lib/fg/event-handlers'
 import {ucfirst} from '../../lib/strings'
@@ -393,6 +394,7 @@ async function onImportFiles (e) {
     // send to backend
     return DatArchive.importFromFilesystem({srcPath, dst, inplaceImport: false})
   }))
+  toast.create(`Imported ${files.length} ${files.length > 1 ? 'files' : 'file'}.`)
 }
 
 function onDragDrop (files) {

--- a/app/stylesheets/builtin-pages/components/toast.less
+++ b/app/stylesheets/builtin-pages/components/toast.less
@@ -16,8 +16,11 @@
 
 .toast {
   max-width: 450px;
+  text-align: center;
   margin: auto;
   background: @background-menu;
+  color: @color-text--muted;
+  font-style: italic;
   padding: 5px 10px;
   box-shadow: 0px 2px 2px rgba(0,0,0,.15);
   border: 1px solid @border-menu;

--- a/app/stylesheets/builtin-pages/components/toast.less
+++ b/app/stylesheets/builtin-pages/components/toast.less
@@ -1,0 +1,24 @@
+@import "../../base/colors.less";
+@import "../../base/spacing.less";
+
+.toast-wrapper {
+  position: fixed;
+  top: @padding-component;
+  width: 100%;
+  z-index: 10;
+
+  transition: opacity .4s ease;
+
+  &.hidden {
+    opacity: 0;
+  }
+}
+
+.toast {
+  max-width: 450px;
+  margin: auto;
+  background: @background-menu;
+  padding: 5px 10px;
+  box-shadow: 0px 2px 2px rgba(0,0,0,.15);
+  border: 1px solid @border-menu;
+}

--- a/app/stylesheets/builtin-pages/editor.less
+++ b/app/stylesheets/builtin-pages/editor.less
@@ -9,6 +9,7 @@
 @import "./components/editor-files-sidebar.less";
 @import "./components/editor-share-popup.less";
 @import "./components/editor-bkr-popup.less";
+@import "./components/toast";
 @import "./components/dropdown-menu-bar.less";
 @import "./components/files-list.less";
 @import "./components/protip.less";


### PR DESCRIPTION
This adds a reusable toast component that can be used on builtin pages. Toasts fade out and are removed from the DOM after just over a second.

```
toast.create('A toast message.')
```
![screen shot 2017-04-08 at 4 04 27 pm](https://cloud.githubusercontent.com/assets/7584833/24832411/380f2a82-1c75-11e7-9267-e8dd66a5046a.png)

