### PR TITLE
open beaker://library instead of beaker://network

### DIFF
--- a/app/shell-window/ui/navbar.js
+++ b/app/shell-window/ui/navbar.js
@@ -542,9 +542,9 @@ function onClickViewFiles (e) {
 function onClickPeers (e) {
   var page = getEventPage(e)
   if (e.metaKey || e.ctrlKey) { // popup
-    pages.setActive(pages.create('beaker://network'))
+    pages.setActive(pages.create('beaker://library'))
   } else {
-    page.loadURL('beaker://network') // goto
+    page.loadURL('beaker://library') // goto
   }
 }
 


### PR DESCRIPTION
I noticed that clicking on the number of peers on a `dat://` site currently opens `beaker://network`, which was recently renamed to `beaker://library`.

<img width="221" alt="screen shot 2017-04-11 at 12 15 29 am" src="https://cloud.githubusercontent.com/assets/1114844/24892640/253d52d4-1e4c-11e7-9313-44222a62d82b.png">

I changed the `onClickPeers` function to open `beaker://library` instead 🙂

I'm super excited for Beaker 0.7 😃 Cheers!