### PR TITLE
V0.7 performance improvements for dat

### DIFF
--- a/app/background-process/networks/dat/library.js
+++ b/app/background-process/networks/dat/library.js
@@ -376,6 +376,7 @@ export function joinSwarm (key, opts) {
   var archive = (typeof key == 'object' && key.key) ? key : getArchive(key)
   if (!archive || archive.isSwarming) return
 
+  var connIdCounter = 0
   var keyStr = datEncoding.toStr(archive.key)
   var swarm = discoverySwarm(swarmDefaults({
     hash: false,
@@ -385,7 +386,7 @@ export function joinSwarm (key, opts) {
       var dkeyStr = datEncoding.toStr(archive.discoveryKey)
       var chan = dkeyStr.slice(0,6) + '..' + dkeyStr.slice(-2)
       var keyStrShort = keyStr.slice(0,6) + '..' + keyStr.slice(-2)
-      var connId = archive.replicationStreams.length
+      var connId = ++connIdCounter
       var start = Date.now()
       debug('new connection id=%s chan=%s type=%s host=%s key=%s', connId, chan, info.type, info.host, keyStrShort)
 

--- a/app/background-process/networks/dat/library.js
+++ b/app/background-process/networks/dat/library.js
@@ -357,6 +357,7 @@ export async function getArchiveInfo (key) {
   ])
   meta.key = key
   meta.url = `dat://${key}`
+  meta.version = archive.version
   meta.userSettings = {localPath: userSettings.localPath, isSaved: userSettings.isSaved}
   meta.peers = archive.metadata.peers.length
   meta.peerHistory = archive.peerHistory

--- a/app/background-process/web-apis/dat-archive.js
+++ b/app/background-process/web-apis/dat-archive.js
@@ -125,15 +125,15 @@ export default {
 
       // if reversing the output, modify start/end
       start = start || 0
-      end = end || archive.version
+      end = end || archive.metadata.length
       if (reverse) {
         // swap values
         let t = start
         start = end
         end = t
         // start from the end
-        start = archive.version - start + 1
-        end = archive.version - end + 1
+        start = archive.metadata.length - start
+        end = archive.metadata.length - end
       }
 
       return new Promise((resolve, reject) => {

--- a/app/builtin-pages/com/library-files-list.js
+++ b/app/builtin-pages/com/library-files-list.js
@@ -100,8 +100,11 @@ function rFile (archiveInfo, node, depth) {
 // event handlers
 // =
 
-function onClickDirectory (e, archiveInfo, node) {
+async function onClickDirectory (e, archiveInfo, node) {
   node.isExpanded = !node.isExpanded
+  if (node.isExpanded) {
+    await archiveInfo.fileTree.readFolder(node)
+  }
   redraw(archiveInfo)
 }
 

--- a/app/builtin-pages/views/library.js
+++ b/app/builtin-pages/views/library.js
@@ -1,6 +1,6 @@
 import * as yo from 'yo-yo'
 import {FileTree, ArchivesList} from 'builtin-pages-lib'
-import {pluralize} from '../../lib/strings'
+import {pluralize, makeSafe} from '../../lib/strings'
 import renderTabs from '../com/tabs'
 import renderGraph from '../com/peer-history-graph'
 import renderFiles from '../com/library-files-list'
@@ -417,24 +417,26 @@ function rDiffMessage (archiveInfo) {
 }
 
 function rHistory (archiveInfo) {
-  var rowEls = []
-  archiveInfo.history.forEach((item, i) => {
-    var rev = archiveInfo.history.length - i
-    var date = item.value ? niceDate(item.value.mtime) : ''
-    rowEls.push(yo`
-      <li class="history-item">
-        <a class="date link" href=${`dat://${archiveInfo.key}+${rev}`} target="_blank">Revision ${rev}</a>
-        ${item.type}
-        ${item.name}
-      </li>
-    `)
+  var len = archiveInfo.history.length
+  var rowEls = archiveInfo.history.map(function (item, i) {
+    var rev = len - i
+    return `
+      <div class="history-item">
+        <div class="date"><a class="link" href=${`dat://${archiveInfo.key}+${rev}`} target="_blank">Revision ${rev}</a></div>
+        ${makeSafe(item.type)}
+        ${makeSafe(item.name)}
+      </div>
+    `
   })
 
   if (rowEls.length === 0) {
-    rowEls.push(yo`<em>Nothing has been published yet.</em>`)
+    rowEls.push(`<em>Nothing has been published yet.</em>`)
   }
 
-  return yo`<ul class="history">${rowEls}</ul>`
+  // use innerHTML instead of yo to speed up this render
+  var el = yo`<div class="history"></div>`
+  el.innerHTML = rowEls.join('')
+  return el
 }
 
 function rMetadata (archiveInfo) {

--- a/app/builtin-pages/views/library.js
+++ b/app/builtin-pages/views/library.js
@@ -110,12 +110,12 @@ async function loadCurrentArchive () {
         await reloadDiff()
       ])
       selectedArchive.history = history
-      selectedArchive.fileTree = fileTree
       selectedArchive.historyPaginationOffset = 500
-      // selectedArchive.events = a.createFileActivityStream()
+      selectedArchive.fileTree = fileTree
+      selectedArchive.events = a.createFileActivityStream()
 
       // wire up events
-      // selectedArchive.events.addEventListener('changed', onFileChanged)
+      selectedArchive.events.addEventListener('changed', onFileChanged)
     } else {
       selectedArchive = null
     }

--- a/app/package.json
+++ b/app/package.json
@@ -28,7 +28,7 @@
     "fs-jetpack": "^0.9.0",
     "function-queue": "0.0.12",
     "get-folder-size": "^1.0.0",
-    "hyperdrive": "^9.0.0",
+    "hyperdrive": "^9.1.0",
     "hyperdrive-staging-area": "^1.1.0",
     "identify-filetype": "^1.0.0",
     "jayson": "^2.0.2",

--- a/app/package.json
+++ b/app/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "await-lock": "^1.1.2",
     "beaker-error-constants": "^1.1.1",
-    "builtin-pages-lib": "git://github.com/beakerbrowser/builtin-pages-lib#8c2b8f69de4718a3d505f95876c20117349adb25",
+    "builtin-pages-lib": "git://github.com/beakerbrowser/builtin-pages-lib#bdbc8260a7e58b83a46a263c29c89ee53853629c",
     "bytes": "^2.5.0",
     "choo": "^5.0.4",
     "co": "^4.6.0",

--- a/app/package.json
+++ b/app/package.json
@@ -41,7 +41,7 @@
     "multicb": "^1.2.1",
     "once": "^1.4.0",
     "parse-dat-url": "^2.0.0",
-    "pauls-dat-api": "^4.0.0",
+    "pauls-dat-api": "^4.1.0",
     "pauls-electron-rpc": "~3.1.0",
     "pify": "^2.3.0",
     "pretty-bytes": "^3.0.1",

--- a/app/stylesheets/builtin-pages/library.less
+++ b/app/stylesheets/builtin-pages/library.less
@@ -291,16 +291,12 @@ body {
 
   .history {
     font-size: 13px;
-
-    .history-item {
-      margin-bottom: .5rem;
-
-      .date {
-        display: inline-block;
-        min-width: 80px;
-        color: @color-text--muted;
-        margin-right: 1rem;
-      }
+    overflow: hidden;
+    white-space: nowrap;
+    
+    .date {
+      display: inline-block;
+      width: 100px;
     }
   }
 

--- a/app/stylesheets/builtin-pages/library.less
+++ b/app/stylesheets/builtin-pages/library.less
@@ -293,10 +293,18 @@ body {
     font-size: 13px;
     overflow: hidden;
     white-space: nowrap;
-    
+
     .date {
       display: inline-block;
       width: 100px;
+    }
+
+    .load-more {
+      display: block;
+      background: @background-button;
+      text-align: center;
+      margin-top: 1em;
+      padding: 1em;
     }
   }
 


### PR DESCRIPTION
 - Fix performance in the file-activity watching algorithm (https://github.com/beakerbrowser/pauls-dat-api/commit/56ad3cecc717b09ba4392664fed8d5c392272f5d). This speeds up both the library view and archive loading perf in general.
 - Improve Library-view performance by loading the file-tree on-demand, instead of everything at once
 - Improve Library-view performance by paginating history