### PR TITLE
Disallow self-modifying dats

### DIFF
--- a/app/background-process/web-apis/dat-archive.js
+++ b/app/background-process/web-apis/dat-archive.js
@@ -404,9 +404,11 @@ async function assertWritePermission (archive, sender) {
     return true
   }
 
-  // self-modification always allowed
+  // self-modification NEVER allowed
   var senderDatKey = await lookupUrlDatKey(sender.getURL())
-  if (senderDatKey === archiveKey) return true
+  if (senderDatKey === archiveKey) {
+    throw new PermissionsError('Dat sites are not allowed to self-modify')
+  }
 
   // ensure the sender is allowed to write
   var allowed = await queryPermission(perm, sender)

--- a/tests/dat-archive-web-api-test.js
+++ b/tests/dat-archive-web-api-test.js
@@ -1316,6 +1316,25 @@ test('archive.createNetworkActivityStream', async t => {
   t.deepEqual(res.value.content.all, true)
 })
 
+test('archive.writeFile does not allow self-modification', async t => {
+  // navigate to the created dat
+  // (we have to be really sleepy about this to not hang the navigation)
+  await sleep(500)
+  var tabIndex = await browserdriver.newTab(app)
+  await sleep(500)
+  await browserdriver.navigateTo(app, createdDatURL)
+  await sleep(500)
+  await app.client.windowByIndex(tabIndex)
+  await app.client.waitForExist('.entry') // an element on the directory listing page
+
+  // fail a self-write
+  var res = await app.client.executeAsync((url, done) => {
+    var archive = new DatArchive(url)
+    archive.writeFile('/denythis.txt', 'hello world', 'utf8').then(done, done)
+  }, createdDatURL)
+  t.deepEqual(res.value.name, 'PermissionsError')
+})
+
 function sleep (time) {
   return new Promise(resolve => setTimeout(resolve, time))
 }


### PR DESCRIPTION
This was a security vulnerability that needed to be closed.

As convenient (and fun) as self-modifying sites are, they dont put a proper perimeter around the application code. Without this policy, it would be possible for an included library to overwrite app code. That would be a Bad Thing.