### PR TITLE
Update security UI on error pages

### DIFF
--- a/app/shell-window/ui/navbar.js
+++ b/app/shell-window/ui/navbar.js
@@ -127,6 +127,7 @@ function render (id, page) {
   const isViewingDat = page && page.getURL().startsWith('dat:')
   const siteHasDatAlternative = page && page.siteHasDatAlternative
   const gotInsecureResponse = page && page.siteLoadError && page.siteLoadError.isInsecureResponse
+  const siteLoadError = page && page.siteLoadError
 
   // back/forward should be disabled if its not possible go back/forward
   var backDisabled = (page && page.canGoBack()) ? '' : 'disabled'
@@ -280,7 +281,7 @@ function render (id, page) {
   `
 
   // a prettified rendering of the main URL input
-  var locationPrettyView = renderPrettyLocation(addrValue, isAddrElFocused, gotInsecureResponse)
+  var locationPrettyView = renderPrettyLocation(addrValue, isAddrElFocused, gotInsecureResponse, siteLoadError)
 
   // render
   return yo`<div data-id=${id} class="toolbar-actions${toolbarHidden}">
@@ -312,7 +313,7 @@ function render (id, page) {
   </div>`
 }
 
-function renderPrettyLocation (value, isHidden, gotInsecureResponse) {
+function renderPrettyLocation (value, isHidden, gotInsecureResponse, siteLoadError) {
   var valueRendered = value
   if (/^(dat|http|https):/.test(value)) {
     try {
@@ -330,7 +331,7 @@ function renderPrettyLocation (value, isHidden, gotInsecureResponse) {
       }
       var cls = 'protocol'
       if (['beaker:'].includes(protocol)) cls += ' protocol-secure'
-      if (['https:'].includes(protocol) && !gotInsecureResponse) cls += ' protocol-secure'
+      if (['https:'].includes(protocol) && !siteLoadError && !gotInsecureResponse) cls += ' protocol-secure'
       if (['https:'].includes(protocol) && gotInsecureResponse) cls += ' protocol-insecure'
       if (['dat:'].includes(protocol)) cls += ' protocol-p2p'
       valueRendered = [

--- a/app/shell-window/ui/navbar/site-info.js
+++ b/app/shell-window/ui/navbar/site-info.js
@@ -22,15 +22,21 @@ export class SiteInfoNavbarBtn {
     var protocolCls = 'insecure'
     var gotInsecureResponse = this.siteLoadError && this.siteLoadError.isInsecureResponse
 
+    if (this.siteLoadError) {
+      icon = 'exclamation-circle'
+      protocolLabel = ''
+    }
+
     if (this.protocolInfo) {
       var isHttps = ['https:'].includes(this.protocolInfo.scheme)
 
-      if (isHttps && !gotInsecureResponse) {
+      if (isHttps && !gotInsecureResponse && !this.siteLoadError) {
         icon = 'lock'
         protocolLabel = 'Secure'
         protocolCls = 'secure'
       } else if (this.protocolInfo.scheme === 'http:' || (isHttps && gotInsecureResponse)) {
-        icon = 'exclamation-circle'
+        icon = 'exclamation-circle https-error'
+        protocolLabel = 'Not secure'
       } else if (['dat:'].indexOf(this.protocolInfo.scheme) != -1) {
         icon = 'share-alt'
         protocolLabel = 'Secure P2P'
@@ -153,7 +159,7 @@ export class SiteInfoNavbarBtn {
 
   closeDropdown() {
     this.isDropdownOpen = false
-    this.updateActives()    
+    this.updateActives()
   }
 
   toggleDropdown(e) {

--- a/app/stylesheets/shell-window/toolbar-input-group.less
+++ b/app/stylesheets/shell-window/toolbar-input-group.less
@@ -66,7 +66,7 @@
       padding-right: 8px;
     }
 
-    &.callout {    
+    &.callout {
       font-size: 12px;
       background: @background-button--active;
       margin: 3px;
@@ -152,14 +152,20 @@
     }
 
     &.insecure {
+      color: @color-text--muted;
 
-      button {
+      .title {
         color: mix(@color-text, @red, 20%);
+        margin-top: 4px;
       }
 
       i {
-        padding-right: 8px;
         padding-top: 5px;
+        color: @color-text--light;
+
+        &.https-error {
+          color: mix(@color-text, @red, 20%);
+        }
       }
     }
 
@@ -184,6 +190,10 @@
     padding: 3px 0 1px 7px;
     cursor: text;
     letter-spacing: -.2px;
+
+    .protocol {
+      color: @color-text--light;
+    }
 
     .protocol-secure {
       color: #3c943c;


### PR DESCRIPTION
This fixes the security UI on error pages and adds a "Not secure" label on pages with HTTPS errors
![screen shot 2017-05-12 at 11 26 11 am](https://cloud.githubusercontent.com/assets/7584833/26007432/0eef82b8-3706-11e7-9e14-3db7e740c015.png)
![screen shot 2017-05-12 at 11 26 19 am](https://cloud.githubusercontent.com/assets/7584833/26007433/0f4eb224-3706-11e7-8a3f-3b8dfbe23ea8.png)



