### PR TITLE
V0.7 handle readonly siteinfo

### DIFF
--- a/app/background-process/networks/dat/library.js
+++ b/app/background-process/networks/dat/library.js
@@ -57,7 +57,7 @@ export function setup () {
     // update the staging based on these settings
     var archive = getArchive(key)
     if (archive) {
-      configureStaging(archive, settings)
+      reconfigureStaging(archive, settings)
     }
   })
 

--- a/app/background-process/networks/dat/library.js
+++ b/app/background-process/networks/dat/library.js
@@ -373,6 +373,11 @@ export async function getArchiveInfo (key) {
 }
 
 export async function reconfigureStaging (archive, userSettings) {
+  if (archive.staging && archive.staging.path === userSettings.localPath) {
+    // no changes needed
+    return
+  }
+
   if (archive.staging) {
     // close staging if it exists
     archive.staging.stopAutoSync()

--- a/app/background-process/ui/modals.js
+++ b/app/background-process/ui/modals.js
@@ -3,6 +3,7 @@ import path from 'path'
 
 const SIZES = {
   'create-archive': {width: 500, height: 390},
+  'create-archive-readonly': {width: 500, height: 250},
   'fork-archive': {width: 500, height: 460},
   prompt: {width: 500, height: 170}
 }
@@ -24,8 +25,8 @@ export function showModal (parentWindow, modalName, opts={}) {
   // create the modal window
   parentWindow = parentWindow || BrowserWindow.getFocusedWindow()
   modalWindow = new BrowserWindow({
-    width: SIZES[modalName].width,
-    height: SIZES[modalName].height,
+    width: SIZES[opts.size || modalName].width,
+    height: SIZES[opts.size || modalName].height,
     parent: parentWindow,
     modal: true,
     show: false,

--- a/app/background-process/web-apis/archives.js
+++ b/app/background-process/web-apis/archives.js
@@ -53,17 +53,22 @@ export default {
   },
 
   async update(url, manifestInfo, {localPath} = {}) {
+    var key = toKey(url)
+    var archive = await datLibrary.getOrLoadArchive(key)
 
     if (!manifestInfo) {
       // show the update-info the modal
-      var win = BrowserWindow.fromWebContents(this.sender)
+      let win = BrowserWindow.fromWebContents(this.sender)
       await assertSenderIsFocused(this.sender)
-      return await showModal(win, 'create-archive', {url})
+      let isReadOnly = !archive.writable
+      return await showModal(win, 'create-archive', {
+        url,
+        isReadOnly,
+        size: isReadOnly ? 'create-archive-readonly' : 'create-archive'
+      })
     }
 
     // update manifest file
-    var key = toKey(url)
-    var archive = await datLibrary.getOrLoadArchive(key)
     var archiveInfo = await archivesDb.getMeta(key)
     var {title, description} = manifestInfo
     title = typeof title !== 'undefined' ? title : archiveInfo.title

--- a/app/builtin-pages/views/create-archive-modal.js
+++ b/app/builtin-pages/views/create-archive-modal.js
@@ -109,9 +109,11 @@ function render () {
   var uititle = isEditing
     ? `Editing ${renderArchiveTitle()}`
     : 'New site'
-  var helpText = isEditing
-    ? 'Update your site\'s title and description.'
-    : 'Create a new site and add it to your library.'
+  var helpText = isReadOnly
+    ? 'Update where you\'d like to save this site.'
+    : isEditing
+      ? 'Update your site\'s title and description.'
+      : 'Create a new site and add it to your library.'
   if (createdBy && !createdBy.startsWith('beaker:')) {
     helpText = 'This page wants to ' + helpText.toLowerCase()
   }

--- a/app/builtin-pages/views/create-archive-modal.js
+++ b/app/builtin-pages/views/create-archive-modal.js
@@ -3,6 +3,7 @@ import {Archive} from 'builtin-pages-lib'
 
 // state
 var isEditing = false
+var isReadOnly = false
 var archive
 
 // form variables
@@ -17,6 +18,7 @@ var createdBy
 window.setup = async function (opts) {
   try {
     isEditing = !!opts.url
+    isReadOnly = !!opts.isReadOnly
     if (opts.url) {
       // fetch archive info
       archive = new Archive(opts.url)
@@ -80,7 +82,10 @@ async function onSubmit (e) {
   e.preventDefault()
   if (!localPath) return
   try {
-    if (isEditing) {
+    if (isReadOnly) {
+      await beaker.archives.add(archive.url, {localPath})
+      beakerBrowser.closeModal(null, true)
+    } else if (isEditing) {
       await beaker.archives.update(archive.url, {title, description}, {localPath})
       beakerBrowser.closeModal(null, true)
     } else {
@@ -128,11 +133,13 @@ function render () {
               <span>${localPath || yo`<span class="placeholder">Folder (required)</span>`}</span>
             </div>
 
-            <label for="title">Title</label>
-            <input name="title" tabindex="2" value=${title || ''} placeholder="Title (optional)" onchange=${onChangeTitle} />
+            ${isReadOnly ? '' : yo`<div>
+              <label for="title">Title</label>
+              <input name="title" tabindex="2" value=${title || ''} placeholder="Title (optional)" onchange=${onChangeTitle} />
 
-            <label for="desc">Description</label>
-            <input name="desc" tabindex="3" value=${description || ''} placeholder="Description (optional)" onchange=${onChangeDescription} />
+              <label for="desc">Description</label>
+              <input name="desc" tabindex="3" value=${description || ''} placeholder="Description (optional)" onchange=${onChangeDescription} />
+            </div>`}
 
             <div class="form-actions">
               <button type="button" onclick=${onClickCancel} class="btn cancel" tabindex="4">Cancel</button>

--- a/app/builtin-pages/views/library.js
+++ b/app/builtin-pages/views/library.js
@@ -306,10 +306,15 @@ function rArchive (archiveInfo) {
                       <i class="fa fa-folder-open-o"></i>
                       Open folder
                     </a>`}
-                <div class="dropdown-item" onclick=${onEditSettings}>
-                  <i class="fa fa-pencil"></i>
-                  Edit site info
-                </div>
+                ${archiveInfo.userSettings.localPath
+                  ? yo`<div class="dropdown-item" onclick=${onEditSettings}>
+                      <i class="fa fa-pencil"></i>
+                      Edit site info
+                    </div>`
+                  : yo`<a class="dropdown-item disabled">
+                      <i class="fa fa-pencil"></i>
+                      Edit site info
+                    </a>`}
                 <div class="dropdown-item" onclick=${onFork}>
                   <i class="fa fa-code-fork"></i>
                   Fork this site


### PR DESCRIPTION
When you click "Edit site info" in the library for readonly archives, you now get this modal:

![screen shot 2017-05-12 at 1 55 46 pm](https://cloud.githubusercontent.com/assets/1270099/26012629/c19c8a0a-371a-11e7-9890-706c316d6e00.png)

