### PR TITLE
Update how toggleables can be closed

### DIFF
--- a/app/builtin-pages/com/downloads-list.js
+++ b/app/builtin-pages/com/downloads-list.js
@@ -1,6 +1,5 @@
 import * as yo from 'yo-yo'
 import prettyBytes from 'pretty-bytes'
-import toggleable from './toggleable'
 import { ucfirst } from '../../lib/strings'
 
 // exported api

--- a/app/builtin-pages/com/toggleable.js
+++ b/app/builtin-pages/com/toggleable.js
@@ -1,4 +1,5 @@
 import * as yo from 'yo-yo'
+import { findParent } from '../../lib/fg/event-handlers'
 
 // globals
 // =
@@ -13,6 +14,7 @@ var toggleState = {}
 // give class .toggleable, .toggleon, or .toggleoff to trigger
 // include data-toggle-on="event", where `event` sets what triggers toggle (default click)
 // include data-toggle-id if you want to keep the toggle state across renderings
+
 export default function toggleable (el) {
   var id = el.dataset.toggleId
 
@@ -24,24 +26,12 @@ export default function toggleable (el) {
 
   Array.from(el.querySelectorAll('.toggleable')).forEach(el2 => {
     el2.addEventListener(el2.dataset.toggleOn||'click', onToggle)
-    el2.addEventListener('keyup', function (e) {
-      if (e.keyCode === 27) onToggle(e)
-    })
-    document.addEventListener('click', onToggle)
   })
   Array.from(el.querySelectorAll('.toggleon')).forEach(el2 => {
     el2.addEventListener(el2.dataset.toggleOn||'click', onToggleOn)
-    el2.addEventListener('keyup', function (e) {
-      if (e.keyCode === 27) onToggleOn(e)
-    })
-    document.addEventListener('click', onToggleOn)
   })
   Array.from(el.querySelectorAll('.toggleoff')).forEach(el2 => {
     el2.addEventListener(el2.dataset.toggleOn||'click', onToggleOff)
-    el2.addEventListener('keyup', function (e) {
-      if (e.keyCode === 27) onToggleOff(e)
-    })
-    document.addEventListener('click', onToggleOff)
   })
 
   function onToggle (e) {
@@ -102,6 +92,17 @@ export function closeToggleable (el) {
   }
 }
 
+// event listeners
+  document.addEventListener('click', function (e) {
+    // if click happens outside of .toggleable-container, close all toggleables
+    if (!findParent(e.target, 'toggleable-container')) {
+      closeAllToggleables()
+    }
+  })
+
+  document.addEventListener('keyup', function (e) {
+    if (e.keyCode === 27) closeAllToggleables()
+  })
 // NOTE
 // look through the commit history for a much nicer version of this
 // there was an edgecase in the old version that I couldnt make work

--- a/app/builtin-pages/com/toggleable.js
+++ b/app/builtin-pages/com/toggleable.js
@@ -41,8 +41,6 @@ export default function toggleable (el) {
     closeAllToggleables()
     if (newState) {
       el.classList.add('open')
-    } else {
-      document.removeEventListener('click', onToggle)
     }
     if (id) {
       // persist state
@@ -62,7 +60,6 @@ export default function toggleable (el) {
     e.preventDefault()
     e.stopPropagation()
     el.classList.remove('open')
-    document.removeEventListener('click', onToggleOff)
     if (id) {
       // persist state
       toggleState[id] = false

--- a/app/builtin-pages/com/toggleable.js
+++ b/app/builtin-pages/com/toggleable.js
@@ -24,13 +24,26 @@ export default function toggleable (el) {
 
   Array.from(el.querySelectorAll('.toggleable')).forEach(el2 => {
     el2.addEventListener(el2.dataset.toggleOn||'click', onToggle)
+    el2.addEventListener('keyup', function (e) {
+      if (e.keyCode === 27) onToggle(e)
+    })
+    document.addEventListener('click', onToggle)
   })
   Array.from(el.querySelectorAll('.toggleon')).forEach(el2 => {
     el2.addEventListener(el2.dataset.toggleOn||'click', onToggleOn)
+    el2.addEventListener('keyup', function (e) {
+      if (e.keyCode === 27) onToggleOn(e)
+    })
+    document.addEventListener('click', onToggleOn)
   })
   Array.from(el.querySelectorAll('.toggleoff')).forEach(el2 => {
     el2.addEventListener(el2.dataset.toggleOn||'click', onToggleOff)
+    el2.addEventListener('keyup', function (e) {
+      if (e.keyCode === 27) onToggleOff(e)
+    })
+    document.addEventListener('click', onToggleOff)
   })
+
   function onToggle (e) {
     e.preventDefault()
     e.stopPropagation()
@@ -38,6 +51,8 @@ export default function toggleable (el) {
     closeAllToggleables()
     if (newState) {
       el.classList.add('open')
+    } else {
+      document.removeEventListener('click', onToggle)
     }
     if (id) {
       // persist state
@@ -57,6 +72,7 @@ export default function toggleable (el) {
     e.preventDefault()
     e.stopPropagation()
     el.classList.remove('open')
+    document.removeEventListener('click', onToggleOff)
     if (id) {
       // persist state
       toggleState[id] = false


### PR DESCRIPTION
This makes it possible to close a toggleable element with ESC and clicking anywhere on the page.

@pfrazee, do we also need to remove the `keyup` event listeners like I do for the `document`'s `click` event?