### PR TITLE
Changes to sites folders and dat.json handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ npm install -g bkr
 
 - `DEBUG`: which log systems to output? A comma-separated string. Can be `beaker`, `dat`, `ipfs`, `bittorrent-dht`, `dns-discovery`, `hypercore-protocol`. Specify `*` for all.
 - `beaker_user_data_path`: override the user-data path, therefore changing where data is read/written. Useful for testing.
+- `beaker_sites_path`: override the default path for saving sites. Useful for testing.
 - `beaker_dat_quota_default_bytes_allowed`: override the default max-quota for bytes allowed to be written by a dat site. Useful for testing.
 
 ## Running the tests

--- a/app/background-process/browser.js
+++ b/app/background-process/browser.js
@@ -294,11 +294,12 @@ export function validateLocalPath (localPath) {
   return {valid: true}
 }
 
-export async function showLocalPathDialog ({folderName, warnIfNotEmpty} = {}) {
+export async function showLocalPathDialog ({folderName, defaultPath, warnIfNotEmpty} = {}) {
   while (true) {
     // prompt for destination
     var localPath = await new Promise((resolve) => {
       dialog.showOpenDialog({
+        defaultPath,
         title: (folderName)
           ? 'Choose where to put the site folder'
           : 'Choose the site folder',

--- a/app/background-process/browser.js
+++ b/app/background-process/browser.js
@@ -312,16 +312,6 @@ export async function showLocalPathDialog ({folderName} = {}) {
       return
     }
 
-    if (folderName) {
-      // find an available variant of folderName
-      let tryNum = 0
-      let folderNameVariant = folderName
-      while (await jetpack.existsAsync(path.join(localPath, folderNameVariant))) {
-        folderNameVariant = `${folderName} (${++tryNum})`
-      }
-      localPath = path.join(localPath, folderNameVariant)
-    }
-
     // make sure it's a valid destination
     let validation = validateLocalPath(localPath)
     if (!validation.valid) {

--- a/app/background-process/browser.js
+++ b/app/background-process/browser.js
@@ -2,9 +2,11 @@ import {app, dialog, autoUpdater, BrowserWindow, webContents, ipcMain, shell} fr
 import os from 'os'
 import path from 'path'
 import fs from 'fs'
+import jetpack from 'fs-jetpack'
 import rpc from 'pauls-electron-rpc'
 import emitStream from 'emit-stream'
 import EventEmitter from 'events'
+import {DISALLOWED_SAVE_PATH_NAMES} from '../lib/const'
 var debug = require('debug')('beaker')
 import manifest from '../lib/api-manifests/internal/browser'
 import * as settingsDb from './dbs/settings'
@@ -82,6 +84,7 @@ export function setup () {
     removeAsDefaultProtocolClient,
 
     showOpenDialog,
+    showLocalPathDialog,
     openUrl: url => { openUrl(url) }, // dont return anything
     openFolder,
     doWebcontentsCmd,
@@ -278,6 +281,88 @@ function showOpenDialog (opts = {}) {
       resolve(filenames)
     })
   })
+}
+
+export function validateLocalPath (localPath) {
+  for (let i=0; i < DISALLOWED_SAVE_PATH_NAMES.length; i++) {
+    let disallowedSavePathName = DISALLOWED_SAVE_PATH_NAMES[i]
+    let disallowedSavePath = app.getPath(disallowedSavePathName)
+    if (path.normalize(localPath) === path.normalize(disallowedSavePath)) {
+      return {valid: false, name: disallowedSavePathName}
+    }
+  }
+  return {valid: true}
+}
+
+export async function showLocalPathDialog ({folderName} = {}) {
+  while (true) {
+    // prompt for destination
+    var localPath = await new Promise((resolve) => {
+      dialog.showOpenDialog({
+        title: (folderName)
+          ? 'Choose where to put the site folder'
+          : 'Choose the site folder',
+        buttonLabel: 'Save',
+        properties: ['openDirectory', 'showHiddenFiles', 'createDirectory']
+      }, filenames => {
+        resolve(filenames && filenames[0])
+      })
+    })
+    if (!localPath) {
+      return
+    }
+
+    if (folderName) {
+      // find an available variant of folderName
+      let tryNum = 0
+      let folderNameVariant = folderName
+      while (await jetpack.existsAsync(path.join(localPath, folderNameVariant))) {
+        folderNameVariant = `${folderName} (${++tryNum})`
+      }
+      localPath = path.join(localPath, folderNameVariant)
+    }
+
+    // make sure it's a valid destination
+    let validation = validateLocalPath(localPath)
+    if (!validation.valid) {
+      var content = validation.name === 'home' ? 'personal data' : validation.name
+      await new Promise(resolve => {
+        dialog.showMessageBox({
+          type: 'error',
+          message: 'This folder is protected. Please pick another folder or subfolder.',
+          detail:
+            `This is the OS ${validation.name} folder. `
+          + `We${"'"}re not comfortable letting you use an important folder, `
+          + `because Beaker has tools and APIs that can delete files. `
+          + `Instead, you should pick a child folder, or some other location entirely.`,
+          buttons: ['OK']
+        }, resolve)
+      })
+      continue
+    }
+
+    // check if the target is empty
+    try {
+      var files = await jetpack.listAsync(localPath)
+      if (files && files.length > 0) {
+        // ask the user if they're sure
+        var res = await new Promise(resolve => {
+          dialog.showMessageBox({
+            type: 'question',
+            message: 'This folder is not empty. Some files may be overwritten. Save to this folder?',
+            buttons: ['Yes', 'Cancel']
+          }, resolve)
+        })
+        if (res != 0) {
+          continue
+        }
+      }
+    } catch (e) {
+      // no files
+    }
+
+    return localPath
+  }
 }
 
 function openFolder (folderPath) {

--- a/app/background-process/browser.js
+++ b/app/background-process/browser.js
@@ -294,7 +294,7 @@ export function validateLocalPath (localPath) {
   return {valid: true}
 }
 
-export async function showLocalPathDialog ({folderName} = {}) {
+export async function showLocalPathDialog ({folderName, warnIfNotEmpty} = {}) {
   while (true) {
     // prompt for destination
     var localPath = await new Promise((resolve) => {
@@ -332,23 +332,25 @@ export async function showLocalPathDialog ({folderName} = {}) {
     }
 
     // check if the target is empty
-    try {
-      var files = await jetpack.listAsync(localPath)
-      if (files && files.length > 0) {
-        // ask the user if they're sure
-        var res = await new Promise(resolve => {
-          dialog.showMessageBox({
-            type: 'question',
-            message: 'This folder is not empty. Some files may be overwritten. Save to this folder?',
-            buttons: ['Yes', 'Cancel']
-          }, resolve)
-        })
-        if (res != 0) {
-          continue
+    if (warnIfNotEmpty) {
+      try {
+        var files = await jetpack.listAsync(localPath)
+        if (files && files.length > 0) {
+          // ask the user if they're sure
+          var res = await new Promise(resolve => {
+            dialog.showMessageBox({
+              type: 'question',
+              message: 'This folder is not empty. Files that are not a part of this site will be deleted or overwritten. Save to this folder?',
+              buttons: ['Yes', 'Cancel']
+            }, resolve)
+          })
+          if (res != 0) {
+            continue
+          }
         }
+      } catch (e) {
+        // no files
       }
-    } catch (e) {
-      // no files
     }
 
     return localPath

--- a/app/background-process/dbs/archives.js
+++ b/app/background-process/dbs/archives.js
@@ -25,10 +25,6 @@ export function setup () {
 }
 
 // get the path to an archive's files
-export function getArchiveStagingPath (archiveOrKey) {
-  var key = datEncoding.toStr(archiveOrKey.key || archiveOrKey)
-  return path.join(datPath, 'Archives', 'Content', key.slice(0, 2), key.slice(2))
-}
 export function getArchiveMetaPath (archiveOrKey) {
   var key = datEncoding.toStr(archiveOrKey.key || archiveOrKey)
   return path.join(datPath, 'Archives', 'Meta', key.slice(0, 2), key.slice(2))

--- a/app/background-process/networks/dat/library.js
+++ b/app/background-process/networks/dat/library.js
@@ -193,6 +193,7 @@ export async function forkArchive (srcArchiveUrl, manifest={}) {
     skipUndownloadedFiles: true,
     ignore: ['/dat.json']
   })
+  await pda.commit(dstArchive.staging)
 
   return dstArchiveUrl
 }

--- a/app/background-process/networks/dat/library.js
+++ b/app/background-process/networks/dat/library.js
@@ -34,7 +34,9 @@ import {
   INVALID_SAVE_FOLDER_CHAR_REGEX
 } from '../../../lib/const'
 import {InvalidURLError} from 'beaker-error-constants'
-const DEFAULT_DATS_FOLDER = path.join(app.getPath('home'), 'Sites')
+const DEFAULT_DATS_FOLDER = process.env.beaker_sites_path
+  ? process.env.beaker_sites_path
+  : path.join(app.getPath('home'), 'Sites')
 
 // globals
 // =

--- a/app/background-process/protocols/dat.js
+++ b/app/background-process/protocols/dat.js
@@ -220,7 +220,7 @@ async function datServer (req, res) {
       'Content-Security-Policy': DAT_CSP,
       'Access-Control-Allow-Origin': '*'
     })
-    res.end(await directoryListingPage(archiveFS, filepath))
+    return res.end(await directoryListingPage(archiveFS, filepath))
   }
 
   // handle not found

--- a/app/background-process/ui/modals.js
+++ b/app/background-process/ui/modals.js
@@ -3,7 +3,6 @@ import path from 'path'
 
 const SIZES = {
   'create-archive': {width: 500, height: 410},
-  'create-archive-readonly': {width: 500, height: 250},
   'fork-archive': {width: 500, height: 460},
   prompt: {width: 500, height: 170}
 }
@@ -25,8 +24,8 @@ export function showModal (parentWindow, modalName, opts={}) {
   // create the modal window
   parentWindow = parentWindow || BrowserWindow.getFocusedWindow()
   modalWindow = new BrowserWindow({
-    width: SIZES[opts.size || modalName].width,
-    height: SIZES[opts.size || modalName].height,
+    width: SIZES[modalName].width,
+    height: SIZES[modalName].height,
     parent: parentWindow,
     modal: true,
     show: false,

--- a/app/background-process/ui/modals.js
+++ b/app/background-process/ui/modals.js
@@ -2,8 +2,8 @@ import {app, BrowserWindow} from 'electron'
 import path from 'path'
 
 const SIZES = {
-  'create-archive': {width: 500, height: 410},
-  'fork-archive': {width: 500, height: 460},
+  'create-archive': {width: 500, height: 340},
+  'fork-archive': {width: 500, height: 390},
   prompt: {width: 500, height: 170}
 }
 

--- a/app/background-process/web-apis/archives.js
+++ b/app/background-process/web-apis/archives.js
@@ -84,8 +84,7 @@ export default {
       title = typeof title !== 'undefined' ? title : archiveInfo.title
       description = typeof description !== 'undefined' ? description : archiveInfo.description
       if (title !== archiveInfo.title || description !== archiveInfo.description) {
-        await pda.updateManifest(archive.stagingFS, {title, description})
-        await pda.commit(archive.stagingFS, {filter: manifestFilter})
+        await pda.updateManifest(archive, {title, description})
         datLibrary.pullLatestArchiveMeta(archive)
       }
     }
@@ -162,9 +161,4 @@ function toKey (url) {
   }
 
   return urlp.host
-}
-
-function manifestFilter (path) {
-  // only allow /dat.json
-  return (path !== '/dat.json') // (true => dont handle)
 }

--- a/app/background-process/web-apis/dat-archive.js
+++ b/app/background-process/web-apis/dat-archive.js
@@ -13,6 +13,7 @@ import {showModal} from '../ui/modals'
 import {timer} from '../../lib/time'
 import {queryPermission, requestPermission} from '../ui/permissions'
 import { 
+  DAT_MANIFEST_FILENAME,
   DAT_HASH_REGEX,
   DAT_QUOTA_DEFAULT_BYTES_ALLOWED,
   DAT_VALID_PATH_REGEX,
@@ -494,7 +495,12 @@ async function lookupArchive (url) {
   if (version) {
     archive.checkoutFS = archive.checkout(+version)
   } else {
-    archive.checkoutFS = archive.stagingFS
+    // access dat.json from archive only (never from staging)
+    if (filepath === '/' + DAT_MANIFEST_FILENAME) {
+      archive.checkoutFS = archive
+    } else {
+      archive.checkoutFS = archive.stagingFS
+    }
   }
 
   return {archive, filepath, version}

--- a/app/builtin-pages/com/archive-changes.js
+++ b/app/builtin-pages/com/archive-changes.js
@@ -18,7 +18,6 @@ export default function renderChanges (archiveInfo, {onPublish, onRevert}) {
   numColumns += archiveInfo.diff.find(d => d.change === 'mod') ? 1 : 0
   numColumns += archiveInfo.diff.find(d => d.change === 'del') ? 1 : 0
   var maxLen = ([100, 35, 20])[numColumns - 1]
-  console.log(maxLen)
 
   // helper to render files
   const rFile = (d, icon, change) => {

--- a/app/builtin-pages/com/files-list.js
+++ b/app/builtin-pages/com/files-list.js
@@ -10,8 +10,10 @@ export default function rFilesList (archiveInfo) {
     return yo`<div class="files-list"></div>`
   }
 
+  var hasFiles = Object.keys(archiveInfo.fileTree.rootNode.children).length > 0
   return yo`
     <div class="files-list">
+      ${!hasFiles ? yo`<div class="item"><em>Empty folder</em></div>` : ''}
       ${rChildren(archiveInfo, archiveInfo.fileTree.rootNode.children)}
     </div>
   `

--- a/app/builtin-pages/views/create-archive-modal.js
+++ b/app/builtin-pages/views/create-archive-modal.js
@@ -3,13 +3,11 @@ import {Archive} from 'builtin-pages-lib'
 
 // state
 var isEditing = false
-var isReadOnly = false
 var archive
 
 // form variables
 var title = ''
 var description = ''
-var localPath = ''
 var createdBy
 
 // exported api
@@ -18,7 +16,6 @@ var createdBy
 window.setup = async function (opts) {
   try {
     isEditing = !!opts.url
-    isReadOnly = !!opts.isReadOnly
     if (opts.url) {
       // fetch archive info
       archive = new Archive(opts.url)
@@ -29,7 +26,6 @@ window.setup = async function (opts) {
     var archiveInfo = archive ? archive.info : {userSettings: {}}
     title = opts.title || archiveInfo.title || ''
     description = opts.description || archiveInfo.description || ''
-    localPath = opts.localPath || archiveInfo.userSettings.localPath || ''
     createdBy = opts.createdBy || undefined
     render()
   } catch (e) {
@@ -60,15 +56,6 @@ function onChangeDescription (e) {
   description = e.target.value
 }
 
-async function onChooseFolder () {
-  var folder = await beakerBrowser.showLocalPathDialog()
-  if (!folder) {
-    return
-  }
-  localPath = folder
-  render()
-}
-
 function onClickCancel (e) {
   e.preventDefault()
   beakerBrowser.closeModal()
@@ -76,16 +63,12 @@ function onClickCancel (e) {
 
 async function onSubmit (e) {
   e.preventDefault()
-  if (!localPath) return
   try {
-    if (isReadOnly) {
-      await beaker.archives.add(archive.url, {localPath})
-      beakerBrowser.closeModal(null, true)
-    } else if (isEditing) {
-      await beaker.archives.update(archive.url, {title, description}, {localPath})
+    if (isEditing) {
+      await beaker.archives.update(archive.url, {title, description})
       beakerBrowser.closeModal(null, true)
     } else {
-      var newArchive = await beaker.archives.create({title, description, createdBy}, {localPath})
+      var newArchive = await beaker.archives.create({title, description, createdBy})
       beakerBrowser.closeModal(null, {url: newArchive.url})
     }
   } catch (e) {
@@ -101,15 +84,12 @@ async function onSubmit (e) {
 // =
 
 function render () {
-  var canSubmit = !!localPath
   var uititle = isEditing
     ? `Editing ${renderArchiveTitle()}`
     : 'New site'
-  var helpText = isReadOnly
-    ? 'Update where you\'d like to save this site.'
-    : isEditing
-      ? 'Update your site\'s title and description.'
-      : 'Create a new site and add it to your library.'
+  var helpText = isEditing
+    ? 'Update your site\'s title and description.'
+    : 'Create a new site and add it to your library.'
   if (createdBy && !createdBy.startsWith('beaker:')) {
     helpText = 'This page wants to ' + helpText.toLowerCase()
   }
@@ -125,23 +105,15 @@ function render () {
           </p>
 
           <form onsubmit=${onSubmit}>
-            <label for="path">Folder</label>
-            <div class="input input-file-picker">
-              <button type="button" class="btn" name="path" tabindex="1" onclick=${onChooseFolder}>Choose folder</button>
-              <span>${localPath || yo`<span class="placeholder">Folder (required)</span>`}</span>
-            </div>
+            <label for="title">Title</label>
+            <input name="title" tabindex="2" value=${title || ''} placeholder="Title (optional)" onchange=${onChangeTitle} />
 
-            ${isReadOnly ? '' : yo`<div>
-              <label for="title">Title</label>
-              <input name="title" tabindex="2" value=${title || ''} placeholder="Title (optional)" onchange=${onChangeTitle} />
-
-              <label for="desc">Description</label>
-              <textarea name="desc" tabindex="3" placeholder="Description (optional)" onchange=${onChangeDescription}>${description || ''}</textarea>
-            </div>`}
+            <label for="desc">Description</label>
+            <textarea name="desc" tabindex="3" placeholder="Description (optional)" onchange=${onChangeDescription}>${description || ''}</textarea>
 
             <div class="form-actions">
               <button type="button" onclick=${onClickCancel} class="btn cancel" tabindex="4">Cancel</button>
-              <button type="submit" class="btn ${isEditing ? ' primary' : ' success'}" tabindex="5" disabled=${!canSubmit}>
+              <button type="submit" class="btn ${isEditing ? ' primary' : ' success'}" tabindex="5">
                 ${isEditing ? 'Save' : 'Create site'}
               </button>
             </div>

--- a/app/builtin-pages/views/create-archive-modal.js
+++ b/app/builtin-pages/views/create-archive-modal.js
@@ -61,15 +61,11 @@ function onChangeDescription (e) {
 }
 
 async function onChooseFolder () {
-  var folders = await beakerBrowser.showOpenDialog({
-    title: 'Choose the folder to contain your site',
-    buttonLabel: 'Select',
-    properties: ['openDirectory', 'createDirectory', 'showHiddenFiles']
-  })
-  if (!folders) {
+  var folder = await beakerBrowser.showLocalPathDialog()
+  if (!folder) {
     return
   }
-  localPath = folders[0]
+  localPath = folder
   render()
 }
 

--- a/app/builtin-pages/views/fork-archive-modal.js
+++ b/app/builtin-pages/views/fork-archive-modal.js
@@ -74,15 +74,11 @@ function onChangeDescription (e) {
 }
 
 async function onChooseFolder () {
-  var folders = await beakerBrowser.showOpenDialog({
-    title: 'Choose the folder to contain your site',
-    buttonLabel: 'Select',
-    properties: ['openDirectory', 'createDirectory', 'showHiddenFiles']
-  })
-  if (!folders) {
+  var folder = await beakerBrowser.showLocalPathDialog({folderName: title})
+  if (!folder) {
     return
   }
-  localPath = folders[0]
+  localPath = folder
   render()
 }
 

--- a/app/builtin-pages/views/fork-archive-modal.js
+++ b/app/builtin-pages/views/fork-archive-modal.js
@@ -10,7 +10,6 @@ var isSelfFork = false
 var title = ''
 var description = ''
 var createdBy
-var localPath = ''
 
 // exported api
 // =
@@ -39,7 +38,6 @@ window.setup = async function (opts) {
     var archiveInfo = archive ? archive.info : {}
     title = opts.title || archiveInfo.title || ''
     description = opts.description || archiveInfo.description || ''
-    localPath = opts.localPath || ''
     createdBy = opts.createdBy || undefined
     render()
 
@@ -73,15 +71,6 @@ function onChangeDescription (e) {
   description = e.target.value
 }
 
-async function onChooseFolder () {
-  var folder = await beakerBrowser.showLocalPathDialog({folderName: title})
-  if (!folder) {
-    return
-  }
-  localPath = folder
-  render()
-}
-
 function onClickCancel (e) {
   e.preventDefault()
   beakerBrowser.closeModal()
@@ -96,9 +85,8 @@ function onClickDownload (e) {
 
 async function onSubmit (e) {
   e.preventDefault()
-  if (!localPath) return
   try {
-    var newArchive = await beaker.archives.fork(archive.info.key, {title, description, createdBy}, {localPath})
+    var newArchive = await beaker.archives.fork(archive.info.key, {title, description, createdBy})
     beakerBrowser.closeModal(null, {url: newArchive.url})
   } catch (e) {
     beakerBrowser.closeModal({
@@ -113,7 +101,6 @@ async function onSubmit (e) {
 // =
 
 function render () {
-  var canSubmit = !!localPath
   var isComplete = archive.info.isOwner || archive.progress.isComplete
   var progressEl, downloadBtn
   if (!isComplete) {
@@ -146,12 +133,6 @@ function render () {
           <p class="help-text">${helpText}</p>
 
           <form onsubmit=${onSubmit}>
-            <label for="path">Folder</label>
-            <div class="input input-file-picker">
-              <button type="button" class="btn" name="path" tabindex="1" onclick=${onChooseFolder}>Choose folder</button>
-              <span>${localPath || yo`<span class="placeholder">Folder (required)</span>`}</span>
-            </div>
-
             <label for="title">Title</label>
             <input name="title" tabindex="2" value=${title} placeholder="Title (optional)" onchange=${onChangeTitle} />
 
@@ -161,7 +142,7 @@ function render () {
             ${progressEl}
             <div class="form-actions">
               <button type="button" class="btn cancel" onclick=${onClickCancel} tabindex="4">Cancel</button>
-              <button type="submit" class="btn ${isComplete ? 'success' : ''}" tabindex="5" disabled=${!canSubmit}>
+              <button type="submit" class="btn ${isComplete ? 'success' : ''}" tabindex="5">
                 Create fork ${!isComplete ? ' anyway' : ''}
               </button>
               ${downloadBtn}

--- a/app/builtin-pages/views/fork-archive-modal.js
+++ b/app/builtin-pages/views/fork-archive-modal.js
@@ -5,6 +5,7 @@ import {Archive} from 'builtin-pages-lib'
 var archive
 var isDownloading = false
 var isSelfFork = false
+var isProcessing = false
 
 // form variables
 var title = ''
@@ -85,7 +86,10 @@ function onClickDownload (e) {
 
 async function onSubmit (e) {
   e.preventDefault()
+  if (isProcessing) return
   try {
+    isProcessing = true
+    render()
     var newArchive = await beaker.archives.fork(archive.info.key, {title, description, createdBy})
     beakerBrowser.closeModal(null, {url: newArchive.url})
   } catch (e) {
@@ -141,9 +145,11 @@ function render () {
 
             ${progressEl}
             <div class="form-actions">
-              <button type="button" class="btn cancel" onclick=${onClickCancel} tabindex="4">Cancel</button>
-              <button type="submit" class="btn ${isComplete ? 'success' : ''}" tabindex="5">
-                Create fork ${!isComplete ? ' anyway' : ''}
+              <button type="button" class="btn cancel" onclick=${onClickCancel} tabindex="4" disabled=${isProcessing}>Cancel</button>
+              <button type="submit" class="btn ${isComplete ? 'success' : ''}" tabindex="5" disabled=${isProcessing}>
+                ${isProcessing
+                  ? yo`<span><span class="spinner"></span> Forking...</span>`
+                  : `Create fork ${!isComplete ? ' anyway' : ''}`}
               </button>
               ${downloadBtn}
             </div>

--- a/app/builtin-pages/views/library.js
+++ b/app/builtin-pages/views/library.js
@@ -326,15 +326,16 @@ function rArchive (archiveInfo) {
                       <i class="fa fa-folder-open-o"></i>
                       Open folder
                     </a>`}
-                ${archiveInfo.userSettings.localPath
+                <div class="dropdown-item" onclick=${onChooseNewLocation}>
+                  <i class="fa fa-folder-o"></i>
+                  Change folder
+                </div>
+                ${archiveInfo.isOwner
                   ? yo`<div class="dropdown-item" onclick=${onEditSettings}>
                       <i class="fa fa-pencil"></i>
                       Edit site info
                     </div>`
-                  : yo`<a class="dropdown-item disabled">
-                      <i class="fa fa-pencil"></i>
-                      Edit site info
-                    </a>`}
+                  : ''}
                 <div class="dropdown-item" onclick=${onFork}>
                   <i class="fa fa-code-fork"></i>
                   Fork this site
@@ -409,8 +410,8 @@ function rMissingLocalPathMessage (archiveInfo) {
         This is probably because the folder was moved or deleted.
       </div>
       <ul>
-        <li>If it was moved, you can <a href="#" onclick=${onUpdateLocation}>update the location</a> and things will resume as before.</li>
-        <li>If it was deleted accidentally (or you dont know what happened) you can <a href="#" onclick=${onUpdateLocation}>choose a
+        <li>If it was moved, you can <a href="#" onclick=${onChooseNewLocation}>update the location</a> and things will resume as before.</li>
+        <li>If it was deleted accidentally (or you dont know what happened) you can <a href="#" onclick=${onChooseNewLocation}>choose a
           new location</a> and we’ll restore the files from the last published state.</li>
         <li>If it was deleted on purpose, and you don’t want to keep the site anymore,
           you can <a href="#" onclick=${onToggleSaved}>delete it from your library</a>.</li>
@@ -645,6 +646,7 @@ async function onRevert () {
     var a = new DatArchive(selectedArchiveKey)
     await a.revert()
     toast.create('Your files have been reverted')
+    reloadDiffThrottled()
   } catch (e) {
     console.error(e)
     toast.create(e.toString())
@@ -655,10 +657,12 @@ async function onFileChanged () {
   reloadDiffThrottled()
 }
 
-async function onUpdateLocation (e) {
+async function onChooseNewLocation (e) {
   e.preventDefault()
-  var localPath = await beakerBrowser.showLocalPathDialog()
-  await beaker.archives.add(selectedArchiveKey, {localPath})
+  var localPath = await beakerBrowser.showLocalPathDialog({
+    warnIfNotEmpty: !selectedArchive.isOwner
+  })
+  await beaker.archives.update(selectedArchiveKey, null, {localPath})
   loadCurrentArchive()
 }
 

--- a/app/builtin-pages/views/library.js
+++ b/app/builtin-pages/views/library.js
@@ -651,7 +651,8 @@ async function onFileChanged () {
 
 async function onUpdateLocation (e) {
   e.preventDefault()
-  await beaker.archives.add(selectedArchiveKey, {promptLocalPath: true})
+  var localPath = await beakerBrowser.showLocalPathDialog()
+  await beaker.archives.add(selectedArchiveKey, {localPath})
   loadCurrentArchive()
 }
 

--- a/app/builtin-pages/views/library.js
+++ b/app/builtin-pages/views/library.js
@@ -660,6 +660,7 @@ async function onFileChanged () {
 async function onChooseNewLocation (e) {
   e.preventDefault()
   var localPath = await beakerBrowser.showLocalPathDialog({
+    defaultPath: selectedArchive.userSettings.localPath,
     warnIfNotEmpty: !selectedArchive.isOwner
   })
   await beaker.archives.update(selectedArchiveKey, null, {localPath})

--- a/app/builtin-pages/views/library.js
+++ b/app/builtin-pages/views/library.js
@@ -296,6 +296,11 @@ function rArchive (archiveInfo) {
         <p class="dat-url code-font">
           <a class="link" href="dat://${archiveInfo.key}">dat://${archiveInfo.key}</a>
         </p>
+        <p class="dat-local-path">
+          <a onclick=${onOpenFolder} href="#">
+            <i class="fa fa-folder-open-o"></i>${archiveInfo.userSettings.localPath}
+          </a>
+        </p>
         <div class="actions">
           <span class="readonly">${archiveInfo.isOwner ? '' : yo`<em>(Read-only)</em>`}</span>
           <a class="btn primary" onclick=${onShare}>
@@ -550,6 +555,7 @@ function onShare (e) {
 }
 
 function onOpenFolder (e) {
+  e.preventDefault()
   if (selectedArchive.userSettings.localPath) {
     beakerBrowser.openFolder(selectedArchive.userSettings.localPath)
   }

--- a/app/lib/api-manifests/internal/browser.js
+++ b/app/lib/api-manifests/internal/browser.js
@@ -18,6 +18,7 @@ export default {
   setStartPageBackgroundImage: 'promise',
 
   showOpenDialog: 'promise',
+  showLocalPathDialog: 'promise',
   openUrl: 'promise',
   openFolder: 'promise',
   doWebcontentsCmd: 'promise',

--- a/app/lib/const.js
+++ b/app/lib/const.js
@@ -1,8 +1,5 @@
 import bytes from 'bytes'
 
-// bkr
-export const BKR_SERVER_PORT = 17760
-
 // 64 char hex
 export const DAT_HASH_REGEX = /^[0-9a-f]{64}$/i
 export const DAT_URL_REGEX = /^(?:dat:\/\/)?([0-9a-f]{64})/i
@@ -16,3 +13,13 @@ export const DAT_QUOTA_DEFAULT_BYTES_ALLOWED = bytes.parse(process.env.beaker_da
 export const DEFAULT_DAT_DNS_TTL = 3600 // 1hr
 export const MAX_DAT_DNS_TTL = 3600 * 24 * 7 // 1 week
 export const DEFAULT_DAT_API_TIMEOUT = 5e3 // 5s
+
+export const DISALLOWED_SAVE_PATH_NAMES = [
+  'home',
+  'desktop',
+  'documents',
+  'downloads',
+  'music',
+  'pictures',
+  'videos'
+]

--- a/app/lib/const.js
+++ b/app/lib/const.js
@@ -14,6 +14,8 @@ export const DEFAULT_DAT_DNS_TTL = 3600 // 1hr
 export const MAX_DAT_DNS_TTL = 3600 * 24 * 7 // 1 week
 export const DEFAULT_DAT_API_TIMEOUT = 5e3 // 5s
 
+// dat staging paths
+export const INVALID_SAVE_FOLDER_CHAR_REGEX = /[^0-9a-zA-Z-_ ]/g
 export const DISALLOWED_SAVE_PATH_NAMES = [
   'home',
   'desktop',

--- a/app/package.json
+++ b/app/package.json
@@ -29,7 +29,7 @@
     "function-queue": "0.0.12",
     "get-folder-size": "^1.0.0",
     "hyperdrive": "^9.1.0",
-    "hyperdrive-staging-area": "^1.2.0",
+    "hyperdrive-staging-area": "^2.0.0",
     "identify-filetype": "^1.0.0",
     "listen-random-port": "^1.0.0",
     "lodash": "^4.17.2",

--- a/app/stylesheets/builtin-pages/fork-archive-modal.less
+++ b/app/stylesheets/builtin-pages/fork-archive-modal.less
@@ -3,6 +3,7 @@
 @import "../components/buttons.less";
 @import "../components/inputs.less";
 @import "../components/modal.less";
+@import "../com/spinner.less";
 
 body {
   background: #fff;

--- a/app/stylesheets/builtin-pages/library.less
+++ b/app/stylesheets/builtin-pages/library.less
@@ -313,6 +313,15 @@ body {
     max-width: 100%;
   }
 
+  .dat-local-path {
+    &:extend(.overflow-ellipsis);
+    max-width: 100%;
+
+    i {
+      margin: 0 4px 0 1px;
+    }  
+  }
+
   .info .actions {
     position: absolute;
     right: 0;

--- a/tests/archives-web-api-test.js
+++ b/tests/archives-web-api-test.js
@@ -31,9 +31,9 @@ test.before(async t => {
   testStaticDatURL = 'dat://' + testStaticDat.archive.key.toString('hex') + '/'
 
   // create a owned archive
-  var res = await app.client.executeAsync((localPath, done) => {
-    beaker.archives.create({}, {localPath}).then(done,done)
-  }, tempy.directory())
+  var res = await app.client.executeAsync((done) => {
+    beaker.archives.create({}).then(done,done)
+  })
   createdDatURL = res.value.url
   createdDatKey = createdDatURL.slice('dat://'.length)
 
@@ -65,9 +65,9 @@ test('library.add, library.remove', async t => {
   })
 
   // by url
-  var res = await app.client.executeAsync((url, localPath, done) => {
-    window.beaker.archives.add(url, {localPath}).then(done,done)
-  }, createdDatURL, tempy.directory())
+  var res = await app.client.executeAsync((url, done) => {
+    window.beaker.archives.add(url).then(done,done)
+  }, createdDatURL)
   t.deepEqual(res.value.isSaved, true)
   var res = await app.client.executeAsync((url, done) => {
     window.beaker.archives.remove(url).then(done,done)
@@ -75,9 +75,9 @@ test('library.add, library.remove', async t => {
   t.deepEqual(res.value.isSaved, false)
 
   // by key
-  var res = await app.client.executeAsync((key, localPath, done) => {
-    window.beaker.archives.add(key, {localPath}).then(done,done)
-  }, createdDatKey, tempy.directory())
+  var res = await app.client.executeAsync((key, done) => {
+    window.beaker.archives.add(key).then(done,done)
+  }, createdDatKey)
   t.deepEqual(res.value.isSaved, true)
   var res = await app.client.executeAsync((key, done) => {
     window.beaker.archives.remove(key).then(done,done)
@@ -94,13 +94,13 @@ test('library.add, library.remove', async t => {
 
 test('library.list', async t => {
   // add the owned and unowned dats
-  var res = await app.client.executeAsync((url, localPath, done) => {
-    window.beaker.archives.add(url, {localPath}).then(done,done)
-  }, createdDatURL, tempy.directory())
+  var res = await app.client.executeAsync((url, done) => {
+    window.beaker.archives.add(url).then(done,done)
+  }, createdDatURL)
   t.deepEqual(res.value.isSaved, true)
-  var res = await app.client.executeAsync((url, localPath, done) => {
-    window.beaker.archives.add(url, {localPath}).then(done,done)
-  }, testStaticDatURL, tempy.directory())
+  var res = await app.client.executeAsync((url, done) => {
+    window.beaker.archives.add(url).then(done,done)
+  }, testStaticDatURL)
   t.deepEqual(res.value.isSaved, true)
 
   // list all
@@ -128,9 +128,9 @@ test('library.list', async t => {
 
 test('library.get', async t => {
   // add the owned and remove the unowned dat
-  var res = await app.client.executeAsync((url, localPath, done) => {
-    window.beaker.archives.add(url, {localPath}).then(done,done)
-  }, createdDatURL, tempy.directory())
+  var res = await app.client.executeAsync((url, done) => {
+    window.beaker.archives.add(url).then(done,done)
+  }, createdDatURL)
   t.deepEqual(res.value.isSaved, true)
   var res = await app.client.executeAsync((url, done) => {
     window.beaker.archives.remove(url).then(done,done)


### PR DESCRIPTION
After some QA, we've hit on some improvements that this PR should make:

- [x] Save all sites to a `~/Sites/{title}` folder by default, rather than always prompting the user where to save
- [x] Show the site's folder more prominently in the library, and give a more prominent "Open folder" button/link
- [x] Include a tool in the library to change the folder after the initial creation/save
- [x] Don't allow special OS folders to be used as the location of sites (eg ~/Documents, ~/Music, etc)
- [x] Allow the sites folder to be overridden by an environment variable
- [x] Don't read/write the dat.json in the staging; instead, just read/write it directly to the archive
- [x] Update tests
- [x] Restore old create/fork tests, now that a file-picker modal isnt required (yay!)
