### PR TITLE
Add {stat:} opt to DatArchive.readdir()

### DIFF
--- a/app/background-process/web-apis/dat-archive.js
+++ b/app/background-process/web-apis/dat-archive.js
@@ -232,7 +232,16 @@ export default {
 
   async readdir(url, opts = {}) {
     var {archive, filepath, version} = await lookupArchive(url, opts)
-    return pda.readdir(archive.checkoutFS, filepath, opts)
+    var names = await pda.readdir(archive.checkoutFS, filepath, opts)
+    if (opts.stat) {
+      for (let i = 0; i < names.length; i++) {
+        names[i] = {
+          name: names[i],
+          stat: await pda.stat(archive.checkoutFS, path.join(filepath, names[i]))
+        }
+      }
+    }
+    return names
   },
 
   async mkdir(url) {

--- a/app/lib/web-apis/dat-archive.js
+++ b/app/lib/web-apis/dat-archive.js
@@ -103,9 +103,13 @@ export default class DatArchive extends EventTarget {
     return dat.download(url, opts)
   }
 
-  readdir(path='/', opts={}) {
+  async readdir(path='/', opts={}) {
     const url = joinPath(this.url, path)
-    return dat.readdir(url, opts)
+    var names = await dat.readdir(url, opts)
+    if (opts.stat) {
+      names.forEach(name => { name.stat = new Stat(name.stat) })
+    }
+    return names
   }
 
   mkdir(path) {

--- a/app/package.json
+++ b/app/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "await-lock": "^1.1.2",
     "beaker-error-constants": "^1.1.1",
-    "builtin-pages-lib": "git://github.com/beakerbrowser/builtin-pages-lib.git#bdbc8260a7e58b83a46a263c29c89ee53853629c",
+    "builtin-pages-lib": "git://github.com/beakerbrowser/builtin-pages-lib.git#5deeae527ef12ac6ac2fc5f11ce50773bd51c847",
     "bytes": "^2.5.0",
     "choo": "^5.6.2",
     "co": "^4.6.0",


### PR DESCRIPTION
Adds an option to `DatArchive` API's `readdir()`

```js
await archive.readdir('/', {stat: true})
/* => [
  {name: 'foo', stat: {...}},
  ...
]*/
