### PR TITLE
Fix: Can now log in to Twitter (close #453)

### DIFF
--- a/app/shell-window/pages.js
+++ b/app/shell-window/pages.js
@@ -695,13 +695,16 @@ function onDidGetRedirectRequest (e) {
   // HACK
   // electron has a problem handling redirects correctly, so we need to handle it for them
   // see https://github.com/electron/electron/issues/3471
-  // thanks github.com/sokcuri for this fix
+  // thanks github.com/sokcuri and github.com/alexstrat for this fix
   // -prf
   if (e.isMainFrame) {
     var page = getByWebview(e.target)
     if (page) {
       e.preventDefault()
-      setTimeout(() => page.loadURL(e.newURL), 100)
+      setTimeout(() => {
+        console.log('Using redirect workaround for electron #3471; redirecting to', e.newURL)
+        e.target.getWebContents().send('redirect-hackfix', e.newURL)
+      }, 100)
     }
   }
 }

--- a/app/webview-preload.js
+++ b/app/webview-preload.js
@@ -5,6 +5,10 @@ import beaker from './lib/web-apis/beaker'
 import { setup as setupLocationbar } from './webview-preload/locationbar'
 import { setup as setupNavigatorPermissions } from './webview-preload/navigator-permissions-api'
 import { setup as setupPrompt } from './webview-preload/prompt'
+import setupRedirectHackfix from './webview-preload/redirect-hackfix'
+
+// HACKS
+setupRedirectHackfix()
 
 // register protocol behaviors
 /* This marks the scheme as:

--- a/app/webview-preload/redirect-hackfix.js
+++ b/app/webview-preload/redirect-hackfix.js
@@ -1,0 +1,13 @@
+// HACK
+// electron has a problem handling redirects correctly, so we need to handle it for them
+// see https://github.com/electron/electron/issues/3471
+// thanks github.com/sokcuri and github.com/alexstrat for this fix
+// -prf
+
+import {ipcRenderer} from 'electron'
+
+export default function () {
+  ipcRenderer.on('redirect-hackfix', function(event, url) {
+    window.location.assign(url)
+  })
+}


### PR DESCRIPTION
Electron has an ongoing problem with redirects. See https://github.com/electron/electron/issues/3471. This updates our hackfix.

This was only tested with simple auth, not 2FA. 