### PR TITLE
Add support for DNS shortnames in the DatArchive API

### DIFF
--- a/app/background-process/web-apis/dat-archive.js
+++ b/app/background-process/web-apis/dat-archive.js
@@ -75,6 +75,7 @@ export default {
     if (!url || typeof url !== 'string') {
       return Promise.reject(new InvalidURLError())
     }
+    url = await datDns.resolveName(url)
     await datLibrary.getOrLoadArchive(url)
     return Promise.resolve(true)
   },
@@ -448,7 +449,7 @@ async function assertSenderIsFocused (sender) {
   }
 }
 
-function parseUrlParts (url) {
+async function parseUrlParts (url) {
   var archiveKey, filepath, version
   if (DAT_HASH_REGEX.test(url)) {
     // simple case: given the key
@@ -462,8 +463,7 @@ function parseUrlParts (url) {
       throw new InvalidURLError('URL must be a dat: scheme')
     }
     if (!DAT_HASH_REGEX.test(urlp.host)) {
-      // TODO- support dns lookup?
-      throw new InvalidURLError('Hostname is not a valid hash')
+      urlp.host = await datDns.resolveName(url)
     }
 
     archiveKey = urlp.host
@@ -483,7 +483,7 @@ async function lookupArchive (url, opts = {}) {
     checkin('searching for archive')
 
     // lookup the archive
-    var {archiveKey, filepath, version} = parseUrlParts(url)
+    var {archiveKey, filepath, version} = await parseUrlParts(url)
     var archive = datLibrary.getArchive(archiveKey)
     if (!archive) archive = await datLibrary.loadArchive(archiveKey)
 

--- a/app/lib/web-apis/dat-archive.js
+++ b/app/lib/web-apis/dat-archive.js
@@ -13,6 +13,11 @@ export default class DatArchive extends EventTarget {
   constructor(url) {
     super()
 
+    // simple case: new DatArchive(window.location)
+    if (url === window.location) {
+      url = window.location.toString()
+    }
+
     // basic URL validation
     if (!url || typeof url !== 'string') {
       throw new Error('Invalid dat:// URL')
@@ -143,6 +148,10 @@ export default class DatArchive extends EventTarget {
   }
 
   static resolveName(name) {
+    // simple case: DatArchive.resolveName(window.location)
+    if (name === window.location) {
+      name = window.location.toString()
+    }
     return dat.resolveName(name)
   }
 

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -258,9 +258,9 @@
       "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4="
     },
     "dat-dns": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/dat-dns/-/dat-dns-1.1.0.tgz",
-      "integrity": "sha1-wb5zRCQHobAdZg7aTOOQRKFIgiU="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/dat-dns/-/dat-dns-1.2.0.tgz",
+      "integrity": "sha512-8sBw5VBRBrVjTOUBnP8Mo9JNsXxERLth+lUVnVM0Wy6+fa2iXZ0MQJkWQkCkBNPN7pD52v3BR+aBrtI5ULQu7w=="
     },
     "dat-encoding": {
       "version": "4.0.2",

--- a/app/package.json
+++ b/app/package.json
@@ -15,7 +15,7 @@
     "choo": "^5.6.2",
     "co": "^4.6.0",
     "concat-stream": "^1.5.2",
-    "dat-dns": "^1.1.0",
+    "dat-dns": "^1.2.0",
     "dat-encoding": "^4.0.2",
     "datland-swarm-defaults": "^1.0.2",
     "debug": "^2.3.3",

--- a/tests/dat-archive-web-api-test.js
+++ b/tests/dat-archive-web-api-test.js
@@ -1403,6 +1403,20 @@ test('archive.writeFile does allow self-modification', async t => {
   t.falsy(res.value)
 })
 
+test('DatArchive can resolve and read dats with shortnames', async t => {
+  // do this in the shell so we dont have to ask permission
+  await app.client.windowByIndex(0)
+
+  var res = await app.client.executeAsync((done) => {
+    var archive = new DatArchive('dat://beakerbrowser.com/')
+    archive.readdir('/').then(done, done)
+  })
+  console.log(res.value)
+  t.truthy(Array.isArray(res.value))
+  
+  await app.client.windowByIndex(1)
+})
+
 function sleep (time) {
   return new Promise(resolve => setTimeout(resolve, time))
 }


### PR DESCRIPTION
This makes it possible to do the following things:

```js
await DatArchive.resolveName('dat://foo.com/bar')
await DatArchive.resolveName(window.location)
new DatArchive('dat://foo.com/bar')
new DatArchive(window.location)
```