### PR TITLE
Fallback the page title to the site title if none is given (close #507)

### DIFF
--- a/app/shell-window/pages.js
+++ b/app/shell-window/pages.js
@@ -611,6 +611,12 @@ function onDidStopLoading (e) {
         beaker.archives.get(key).then(info => {
           page.siteInfo = info
           navbar.update(page)
+
+          // fallback the tab title to the site title, if needed
+          if (page.getTitle() === page.getURL() && info.title) {
+            page.title = info.title
+            events.emit('page-title-updated', page)
+          }
         })
       })
     }


### PR DESCRIPTION
![screen shot 2017-06-15 at 2 50 25 pm](https://user-images.githubusercontent.com/1270099/27199076-59bbecde-51da-11e7-9810-6bb9232560f8.png)

(^ Previously it would have just shown the URL in the tab title)