### PR TITLE
Simplified saved readonly Dat archives

### DIFF
--- a/app/background-process/networks/dat/library.js
+++ b/app/background-process/networks/dat/library.js
@@ -8,7 +8,7 @@ import pda from 'pauls-dat-api'
 import signatures from 'sodium-signatures'
 import slugify from 'slugify'
 var debug = require('debug')('dat')
-import {debounce} from '../../../lib/functions'
+import {throttle, debounce} from '../../../lib/functions'
 import {grantPermission} from '../../ui/permissions'
 
 // dat modules
@@ -73,7 +73,8 @@ export function setup () {
     // update the staging based on these settings
     var archive = getArchive(key)
     if (archive) {
-      reconfigureStaging(archive, settings)
+      configureStaging(archive, settings)
+      configureAutoDownload(archive, settings)
     }
   })
 
@@ -309,6 +310,7 @@ async function loadArchiveInner (key, secretKey, userSettings=null) {
   })
   await configureStaging(archive, userSettings, !!secretKey)
   await updateSizeTracking(archive)
+  configureAutoDownload(archive, userSettings)
   archivesDb.touch(key).catch(err => console.error('Failed to update lastAccessTime for archive', key, err))
 
   // store in the discovery listing, so the swarmer can find it
@@ -434,20 +436,21 @@ export async function getArchiveInfo (key) {
   return meta
 }
 
-export async function reconfigureStaging (archive, userSettings) {
+export async function configureStaging (archive, userSettings, isWritableOverride) {
+  var isWritable = (archive.writable || isWritableOverride)
   if (archive.staging && archive.staging.path === userSettings.localPath) {
     // no further changes needed
     return
   }
 
-  if (archive.staging) {
-    // close staging if it exists
-    archive.staging.stopAutoSync()
+  // recreate staging
+  if (isWritable && !!userSettings.localPath) {
+    archive.staging = hyperstaging(archive, userSettings.localPath, {
+      ignore: ['/.dat', '/.git', '/dat.json']
+    })
+  } else {
     archive.staging = null
   }
-
-  // recreate staging
-  await configureStaging(archive, userSettings)
 }
 
 export async function selectDefaultLocalPath (title) {
@@ -553,33 +556,34 @@ function fromKeyToURL (key) {
   return key
 }
 
-async function configureStaging (archive, userSettings, isWritableOverride) {
-  // create staging if writable or saved
-  var isWritable = (archive.writable || isWritableOverride)
-  var isSaved = userSettings.isSaved
-  if ((isWritable || isSaved) && !!userSettings.localPath) {
-    if (archive.staging) {
-      return // noop
-    }
-
-    // setup staging
-    let stagingPath = userSettings.localPath
-    archive.staging = hyperstaging(archive, stagingPath, {
-      ignore: ['/.dat', '/.git', '/dat.json']
-    })
-
-    // autosync if not writable
-    if (!isWritable) {
-      archive.staging.revert({skipDatIgnore: true}) // do a revert to capture already-DLed state
-      archive.staging.startAutoSync()
-    }
-  } else {
-    // close staging if it exists
-    if (archive.staging) {
-      archive.staging.stopAutoSync()      
-    }
-    archive.staging = null
+function configureAutoDownload (archive, userSettings) {
+  if (archive.writable) {
+    return // abort, only used for unwritable
   }
+  // HACK
+  // mafintosh is planning to put APIs for this inside of hyperdrive
+  // till then, we'll do our own inefficient downloader
+  // -prf
+  if (!archive._autodownloader && userSettings.isSaved) {
+    // setup the autodownload
+    archive._autodownloader = {
+      undownloadAll: () => {
+        archive.content._selections.forEach(range => archive.content.undownload(range))
+      },
+      onUpdate: throttle(() => {
+        // cancel ALL previous, then prioritize ALL current
+        archive._autodownloader.undownloadAll()
+        pda.download(archive, '/')
+      }, 5e3)
+    }
+    archive.metadata.on('download', archive._autodownloader.onUpdate)
+    pda.download(archive, '/')
+  } else if (archive._autodownloader && !userSettings.isSaved) {
+    // tear down the autodownload
+    archive._autodownloader.undownloadAll()
+    archive.metadata.removeListener('download', archive._autodownloader.onUpdate)
+    archive._autodownloader = null
+  } 
 }
 
 var connIdCounter = 0 // for debugging

--- a/app/background-process/web-apis/archives.js
+++ b/app/background-process/web-apis/archives.js
@@ -94,7 +94,7 @@ export default {
     if (localPath) {
       var oldLocalPath = archive.staging ? archive.staging.path : false
       var userSettings = await archivesDb.setUserSettings(0, key, {localPath})
-      await datLibrary.reconfigureStaging(archive, userSettings)
+      await datLibrary.configureStaging(archive, userSettings)
       if (localPath !== oldLocalPath) {
         datLibrary.deleteOldStagingFolder(oldLocalPath)
       }
@@ -110,11 +110,13 @@ export default {
 
     // select a default local path, if needed
     var localPath
-    try {
-      let userSettings = await archivesDb.getUserSettings(0, key)
-      localPath = userSettings.localPath
-    } catch (e) {}
-    localPath = localPath || await datLibrary.selectDefaultLocalPath(meta.title)
+    if (archive.writable) {
+      try {
+        let userSettings = await archivesDb.getUserSettings(0, key)
+        localPath = userSettings.localPath
+      } catch (e) {}
+      localPath = localPath || await datLibrary.selectDefaultLocalPath(meta.title)
+    }
 
     // update settings
     return archivesDb.setUserSettings(0, key, {isSaved: true, localPath})

--- a/app/builtin-pages/views/library.js
+++ b/app/builtin-pages/views/library.js
@@ -415,7 +415,7 @@ function rNotSaved (archiveInfo) {
 }
 
 function rMissingLocalPathMessage (archiveInfo) {
-  if (!archiveInfo.userSettings.isSaved || archiveInfo.localPathExists) {
+  if (!archiveInfo.isOwner || !archiveInfo.userSettings.isSaved || archiveInfo.localPathExists) {
     return ''
   }
   return yo`


### PR DESCRIPTION
Previously, saved read-only dats were synced to a local staging path. This had two problems:

 1. Poor performance (https://github.com/beakerbrowser/beaker/issues/541)
 2. The folder placed on disk was confusing to users, who thought they'd be able to edit the files. In fact, they could, but when the source Archive did an update, their changes were overwritten.

This PR accompanies some already-made UI changes, which gets rid of the local staging path for readonly dats, and instead just syncs to internal storage. The final step will be to add a "Download as Zip" control, which lets the user get snapshots of the archive. That will be a future PR.

![screen shot 2017-06-16 at 12 30 54 pm](https://user-images.githubusercontent.com/1270099/27237709-deb85e76-528f-11e7-8e0b-9ee862114a1d.png)
