### PR TITLE
Improve sidebar controls in the navbar

### DIFF
--- a/app/shell-window/ui/navbar.js
+++ b/app/shell-window/ui/navbar.js
@@ -1,5 +1,6 @@
 import { remote } from 'electron'
 import * as pages from '../pages'
+import * as sidebar from './sidebar'
 import * as zoom from '../pages/zoom'
 import * as yo from 'yo-yo'
 import emitStream from 'emit-stream'
@@ -201,7 +202,7 @@ function render (id, page) {
 
     datBtns = [
       yo`
-        <button class="nav-peers-btn">
+        <button class="nav-peers-btn" onclick=${onClickPeercount}>
           <i class="fa fa-share-alt"></i> ${numPeers} ${pluralize(numPeers, 'peer')}
         </button>`,
       yo`<button class="nav-live-reload-btn ${isLiveReloading ? 'active': ''}" title="Turn {$isLiveReloading ? 'off' : 'on'} live reloading" onclick=${onClickLiveReload}>
@@ -547,6 +548,10 @@ function onClickBookmark (e) {
   if (page) {
     page.toggleBookmark()
   }
+}
+
+function onClickPeercount (e) {
+  sidebar.toggle()
 }
 
 function onClickLiveReload (e) {

--- a/app/shell-window/ui/navbar/dat-sidebar.js
+++ b/app/shell-window/ui/navbar/dat-sidebar.js
@@ -4,12 +4,13 @@ import * as sidebar from '../sidebar'
 
 export class DatSidebarBtn {
   constructor () {
+    sidebar.on('change', this.updateActives.bind(this))
   }
 
   render () {
     const pressed = sidebar.getIsOpen() ? 'pressed' : ''
     return yo`
-      <button title="Toggle sidebar" class="toolbar-btn dat-sidebar btn ${pressed}" onclick=${e => this.onClickBtn(e)} title="Menu">
+      <button title="Toggle sidebar" class="toolbar-btn dat-sidebar btn ${pressed}" onclick=${e => this.onClickBtn(e)}>
         <i class="fa fa-columns"></i>
       </button>
     `
@@ -25,11 +26,6 @@ export class DatSidebarBtn {
   }
 
   updateActives() {
-    // FIXME
-    // calling `this.render` for all active site-infos is definitely wrong
-    // there is state captured in `this` that is specific to each instance
-    // ...this entire thing is kind of bad
-    // -prf
     Array.from(document.querySelectorAll('.dat-sidebar.btn')).forEach(el => yo.update(el, this.render()))
   }
 }

--- a/app/shell-window/ui/navbar/dat-sidebar.js
+++ b/app/shell-window/ui/navbar/dat-sidebar.js
@@ -7,8 +7,9 @@ export class DatSidebarBtn {
   }
 
   render () {
+    const pressed = sidebar.getIsOpen() ? 'pressed' : ''
     return yo`
-      <button title="Toggle sidebar" class="toolbar-btn dat-sidebar btn" onclick=${e => this.onClickBtn(e)} title="Menu">
+      <button title="Toggle sidebar" class="toolbar-btn dat-sidebar btn ${pressed}" onclick=${e => this.onClickBtn(e)} title="Menu">
         <i class="fa fa-columns"></i>
       </button>
     `

--- a/app/shell-window/ui/sidebar.js
+++ b/app/shell-window/ui/sidebar.js
@@ -1,8 +1,10 @@
+import EventEmitter from 'events'
 import * as pages from '../pages'
 
 var isOpen = false
 var isDragging = false
 
+var events = new EventEmitter()
 var webviewsEl
 var sidebarEl
 var sidebarWebviews = {} // pageId => webview element
@@ -11,6 +13,10 @@ var sidebarWidth = 300
 
 // exported api
 // =
+
+export function on (...args) {
+  events.on.apply(events, args)
+}
 
 export function getIsOpen () {
   return isOpen
@@ -39,6 +45,7 @@ export function open (page) {
     isOpen = true
     sidebarEl.classList.add('open')
     doResize()
+    events.emit('change')
   }
 
   // create the webview for the given page, if dne
@@ -112,6 +119,7 @@ export function close () {
     sidebarEl.classList.remove('open')
     destroyWebviews()
     doResize()
+    events.emit('change')
   }
 }
 

--- a/app/stylesheets/shell-window/toolbar-actions.less
+++ b/app/stylesheets/shell-window/toolbar-actions.less
@@ -18,6 +18,7 @@
     line-height: 1.1;
     color: @color-toolbar-btn;
     width: 28px;
+    height: 28px;
     border-radius: 2px;
     border: 1px solid transparent;
 

--- a/app/stylesheets/shell-window/toolbar-input-group.less
+++ b/app/stylesheets/shell-window/toolbar-input-group.less
@@ -91,11 +91,6 @@
 
     &.nav-peers-btn {
       font-size: 14px;
-
-      &:hover {
-        cursor: default;
-        background: none;
-      }
     }
 
     &.nav-bookmark-btn,


### PR DESCRIPTION
Can now click the peer count, and easily tell if the panel is open
![new-sidebar-ctrls](https://user-images.githubusercontent.com/1270099/27342483-f90abfee-55a5-11e7-87f4-deda4a850cec.gif)

