### PR TITLE
Add DatArchive API to HTTPS sites

### DIFF
--- a/app/background-process/web-apis.js
+++ b/app/background-process/web-apis.js
@@ -1,6 +1,6 @@
 import {ipcMain} from 'electron'
 import rpc from 'pauls-electron-rpc'
-import {internalOnly} from '../lib/bg/rpc'
+import {internalOnly, secureOnly} from '../lib/bg/rpc'
 
 // internal manifests
 import beakerBrowser from '../lib/api-manifests/internal/browser'
@@ -35,7 +35,7 @@ export function setup () {
   rpc.exportAPI('history', historyManifest, historyAPI, internalOnly)
 
   // external apis
-  rpc.exportAPI('dat-archive', datArchiveManifest, datArchiveAPI)
+  rpc.exportAPI('dat-archive', datArchiveManifest, datArchiveAPI, secureOnly)
 
   // register a message-handler for setting up the client
   // - see lib/fg/import-web-apis.js

--- a/app/lib/bg/rpc.js
+++ b/app/lib/bg/rpc.js
@@ -3,3 +3,11 @@ import rpc from 'pauls-electron-rpc'
 export function internalOnly (event, methodName, args) {
   return (event && event.sender && event.sender.getURL().startsWith('beaker:'))
 }
+
+export function secureOnly (event, methodName, args) {
+  if (!(event && event.sender)) {
+    return false
+  }
+  var url = event.sender.getURL()
+  return url.startsWith('beaker:') || url.startsWith('dat:') || url.startsWith('https:')
+}

--- a/app/webview-preload.js
+++ b/app/webview-preload.js
@@ -21,8 +21,10 @@ webFrame.registerURLSchemeAsPrivileged('dat', { bypassCSP: false })
 
 // setup APIs
 importWebAPIs()
-if (['beaker:','dat:'].includes(window.location.protocol)) {
+if (['beaker:','dat:','https:'].includes(window.location.protocol)) {
   window.DatArchive = DatArchive
+}
+if (window.location.protocol === 'beaker:') {
   window.beaker = beaker
 }
 setupLocationbar()


### PR DESCRIPTION
Closes https://github.com/beakerbrowser/beaker/issues/553

Exposing the DatArchive to HTTPS makes it possible for traditional service-based applications to publish and consume using Dat. This has benefits to everybody involved. For the standard end-user, you get more control over their data, and less lockin. For the service developer, you get a cost-saving technology, and the capabilities of the service itself.

As of this PR, a page served over HTTPS can access [`DatArchive`](https://beakerbrowser.com/docs/apis/dat.html).