### PR TITLE
Allow http://localhost to access DatArchive apis

### DIFF
--- a/app/lib/bg/rpc.js
+++ b/app/lib/bg/rpc.js
@@ -1,5 +1,7 @@
 import rpc from 'pauls-electron-rpc'
 
+const SECURE_ORIGIN_REGEX = /^(beaker:|dat:|https:|http:\/\/localhost(\/|:))/i
+
 export function internalOnly (event, methodName, args) {
   return (event && event.sender && event.sender.getURL().startsWith('beaker:'))
 }
@@ -9,5 +11,5 @@ export function secureOnly (event, methodName, args) {
     return false
   }
   var url = event.sender.getURL()
-  return url.startsWith('beaker:') || url.startsWith('dat:') || url.startsWith('https:')
+  return SECURE_ORIGIN_REGEX.test(url)
 }

--- a/app/webview-preload.js
+++ b/app/webview-preload.js
@@ -21,7 +21,8 @@ webFrame.registerURLSchemeAsPrivileged('dat', { bypassCSP: false })
 
 // setup APIs
 importWebAPIs()
-if (['beaker:','dat:','https:'].includes(window.location.protocol)) {
+if (['beaker:','dat:','https:'].includes(window.location.protocol) || 
+    (window.location.protocol === 'http:' && window.location.hostname === 'localhost')) {
   window.DatArchive = DatArchive
 }
 if (window.location.protocol === 'beaker:') {


### PR DESCRIPTION
This is a follow up to https://github.com/beakerbrowser/beaker/pull/586

Makes it possible to access DatArchive APIs from `http://localhost`, which is important for testing