### PR TITLE
Improvements to dat configuration

### DIFF
--- a/app/background-process/dbs/archives.js
+++ b/app/background-process/dbs/archives.js
@@ -165,11 +165,9 @@ export async function setUserSettings (profileId, key, newValues = {}) {
   var release = await lock('archives-db')
   try {
     // fetch current
-    var value = await db.get(`
-      SELECT * FROM archives WHERE profileId = ? AND key = ?
-    `, [profileId, key])
+    var value = await getUserSettings(profileId, key)
 
-    if (!value) {
+    if (typeof value.key === 'undefined') {
       // create
       value = {
         profileId,

--- a/app/background-process/dbs/profile-data-db.js
+++ b/app/background-process/dbs/profile-data-db.js
@@ -51,7 +51,8 @@ export function parallelize () {
 migrations = [
   migration('profile-data.v1.sql'),
   migration('profile-data.v2.sql'),
-  migration('profile-data.v3.sql')
+  migration('profile-data.v3.sql'),
+  migration('profile-data.v4.sql')
 ]
 function migration (file) {
   return cb => db.exec(fs.readFileSync(path.join(__dirname, 'background-process', 'dbs', 'schemas', file), 'utf8'), cb)

--- a/app/background-process/dbs/schemas/profile-data.v4.sql
+++ b/app/background-process/dbs/schemas/profile-data.v4.sql
@@ -1,0 +1,6 @@
+
+-- add flags to control swarming behaviors of archives
+ALTER TABLE archives ADD COLUMN autoDownload INTEGER DEFAULT 1;
+ALTER TABLE archives ADD COLUMN autoUpload INTEGER DEFAULT 1;
+
+PRAGMA user_version = 4;

--- a/app/background-process/networks/dat/library.js
+++ b/app/background-process/networks/dat/library.js
@@ -66,7 +66,9 @@ export function setup () {
     // emit event
     var details = {
       url: 'dat://' + key,
-      isSaved: settings.isSaved
+      isSaved: settings.isSaved,
+      autoDownload: settings.autoDownload,
+      autoUpload: settings.autoUpload
     }
     archivesEvents.emit(settings.isSaved ? 'added' : 'removed', {details})
 
@@ -426,7 +428,12 @@ export async function getArchiveInfo (key) {
   meta.metaSize = archive.metaSize
   meta.stagingSize = archive.stagingSize
   meta.stagingSizeLessIgnored = archive.stagingSizeLessIgnored
-  meta.userSettings = {localPath: userSettings.localPath, isSaved: userSettings.isSaved}
+  meta.userSettings = {
+    localPath: userSettings.localPath,
+    isSaved: userSettings.isSaved,
+    autoDownload: userSettings.autoDownload,
+    autoUpload: userSettings.autoUpload
+  }
   meta.peers = archive.metadata.peers.length
   meta.peerInfo = archive.replicationStreams.map(s => ({
     host: s.peerInfo.host,
@@ -565,7 +572,8 @@ function configureAutoDownload (archive, userSettings) {
   // mafintosh is planning to put APIs for this inside of hyperdrive
   // till then, we'll do our own inefficient downloader
   // -prf
-  if (!archive._autodownloader && userSettings.isSaved) {
+  const isAutoDownloading = userSettings.isSaved && userSettings.autoDownload
+  if (!archive._autodownloader && isAutoDownloading) {
     // setup the autodownload
     archive._autodownloader = {
       undownloadAll: () => {
@@ -579,7 +587,7 @@ function configureAutoDownload (archive, userSettings) {
     }
     archive.metadata.on('download', archive._autodownloader.onUpdate)
     pda.download(archive, '/').catch(e => {/* ignore cancels */})
-  } else if (archive._autodownloader && !userSettings.isSaved) {
+  } else if (archive._autodownloader && !isAutoDownloading) {
     // tear down the autodownload
     archive._autodownloader.undownloadAll()
     archive.metadata.removeListener('download', archive._autodownloader.onUpdate)

--- a/app/background-process/web-apis/archives.js
+++ b/app/background-process/web-apis/archives.js
@@ -58,12 +58,12 @@ export default {
     return datLibrary.forkArchive(url, {title, description, createdBy})
   },
 
-  async update(url, manifestInfo, {localPath} = {}) {
+  async update(url, manifestInfo, userSettings) {
     var key = toKey(url)
     var archive = await datLibrary.getOrLoadArchive(key)
 
     // no info provided: open modal
-    if (!manifestInfo && !localPath) {
+    if (!manifestInfo && !userSettings) {
       if (!archive.writable) {
         throw new ArchiveNotWritableError()
       }
@@ -74,7 +74,7 @@ export default {
     }
 
     // validate path
-    if (localPath && !validateLocalPath(localPath).valid) {
+    if (userSettings && userSettings.localPath && !validateLocalPath(userSettings.localPath).valid) {
       throw new InvalidPathError('Cannot save the site to that folder')
     }
 
@@ -91,11 +91,11 @@ export default {
     }
 
     // update settings
-    if (localPath) {
+    if (userSettings) {
       var oldLocalPath = archive.staging ? archive.staging.path : false
-      var userSettings = await archivesDb.setUserSettings(0, key, {localPath})
+      var userSettings = await archivesDb.setUserSettings(0, key, userSettings)
       await datLibrary.configureStaging(archive, userSettings)
-      if (localPath !== oldLocalPath) {
+      if (userSettings.localPath && userSettings.localPath !== oldLocalPath) {
         datLibrary.deleteOldStagingFolder(oldLocalPath)
       }
     }

--- a/app/background-process/web-apis/archives.js
+++ b/app/background-process/web-apis/archives.js
@@ -202,9 +202,12 @@ export default {
 
   async get(url, opts) {
     return timer(to(opts), async (checkin) => {
-      var key = toKey(url)
-      return datLibrary.getArchiveInfo(key)
+      return datLibrary.getArchiveInfo(toKey(url))
     })
+  },
+
+  async clearFileCache(url) {
+    return datLibrary.clearFileCache(toKey(url))
   },
 
   clearDnsCache() {

--- a/app/builtin-pages/views/dat-sidebar.js
+++ b/app/builtin-pages/views/dat-sidebar.js
@@ -550,7 +550,7 @@ function rSettings (archiveInfo) {
           `,
       yo`
         <div class="setting ${!isSaved?'disabled':''}">
-          <h5>Download</h5>
+          <h5>Download files</h5>
           <fieldset>
             <label onclick=${(e) => onSetAutoDownload(e, false)}>
               <input type="radio" name="download_setting" disabled=${!isSaved} checked=${!isChecked.autoDownload} />

--- a/app/builtin-pages/views/library.js
+++ b/app/builtin-pages/views/library.js
@@ -338,10 +338,10 @@ function rViewHeader (archiveInfo) {
   } else {
     if (archiveInfo.userSettings.isSaved) {
       toggleSaveIcon = 'fa-times-circle'
-      toggleSaveText = 'Stop syncing'
+      toggleSaveText = 'Remove from library'
     } else {
-      toggleSaveIcon = 'fa-check-circle'
-      toggleSaveText = 'Sync for offline'
+      toggleSaveIcon = 'fa-plus'
+      toggleSaveText = 'Add to library'
     }
   }
 

--- a/app/builtin-pages/views/library.js
+++ b/app/builtin-pages/views/library.js
@@ -309,14 +309,14 @@ function rArchive (archiveInfo) {
       <section class="tabs-content">
         ${renderTabs(currentSection, [
           {id: 'files', label: 'Published files', onclick: onClickTab('files')},
-          {id: 'metadata', label: 'About', onclick: onClickTab('metadata')},
           {id: 'log', label: 'History', onclick: onClickTab('log')},
-          {id: 'network', label: 'Network', onclick: onClickTab('network')}
+          {id: 'network', label: 'Network', onclick: onClickTab('network')},
+          {id: 'settings', label: 'Settings', onclick: onClickTab('settings')}
         ].filter(Boolean))}
         ${({
           files: () => rFiles(archiveInfo),
           log: () => rHistory(archiveInfo),
-          metadata: () => rMetadata(archiveInfo),
+          settings: () => rSettings(archiveInfo),
           network: () => rNetwork(archiveInfo)
         })[currentSection]()}
       </section>
@@ -574,7 +574,14 @@ function rHistory (archiveInfo) {
   return yo`<div class="history">${rowEls}${loadMoreBtn}</div>`
 }
 
-function rMetadata (archiveInfo) {
+function rSettings (archiveInfo) {
+  const isSaved = archiveInfo.userSettings.isSaved
+  const isChecked = {
+    autoDownload: isSaved && archiveInfo.userSettings.autoDownload,
+    autoUpload: isSaved && archiveInfo.userSettings.autoDownload
+  }
+
+  // editable title and description
   var titleEl, descEl
   if (archiveInfo.isOwner && isEditingInfo) {
     titleEl = yo`
@@ -602,7 +609,11 @@ function rMetadata (archiveInfo) {
     titleEl = yo`<td>${niceName(archiveInfo)}</td>`
     descEl = yo`<td>${niceDesc(archiveInfo)}</td>`
   }
+
+  // tools that differ if owner
   var sizeRows
+  var networkSettingsEls
+  var toolsEls
   if (archiveInfo.isOwner) {
     sizeRows = [
       yo`<tr><td class="label">Staging</td><td>${prettyBytes(archiveInfo.stagingSizeLessIgnored)} (${prettyBytes(archiveInfo.stagingSize - archiveInfo.stagingSizeLessIgnored)} ignored)</td></tr>`,
@@ -610,9 +621,39 @@ function rMetadata (archiveInfo) {
     ]
   } else {
     sizeRows = yo`<tr><td class="label">Size</td><td>${prettyBytes(archiveInfo.metaSize)}</td></tr>`
+    networkSettingsEls = [
+      isSaved
+        ? ''
+        : yo`
+            <p><a onclick=${onToggleSaved} class="link">Add this site to your library</a> to configure the download settings.</p>
+          `,
+      yo`
+        <div class="setting ${!isSaved?'disabled':''}">
+          <h5>Download files</h5>
+          <fieldset>
+            <label onclick=${(e) => onSetAutoDownload(e, false)}>
+              <input type="radio" name="download_setting" disabled=${!isSaved} checked=${!isChecked.autoDownload} />
+              When I visit
+            </label>
+            <label onclick=${(e) => onSetAutoDownload(e, true)}>
+              <input type="radio" name="download_setting" disabled=${!isSaved} checked=${isChecked.autoDownload} />
+              Always <span class="muted">(Sync for offline use)</span>
+            </label>
+          </fieldset>
+        </div>
+      `
+    ]
+    toolsEls = yo`
+      <div class="tools">
+        <a class="link" onclick=${onDeleteDownloadedFiles}><i class="fa fa-trash"></i> Delete downloaded files</a>
+      </div>
+    `
   }
+
+  // render
   return yo`
-    <div class="metadata">
+    <div class="settings">
+      ${networkSettingsEls}
       <table>
         <tr><td class="label">Title</td>${titleEl}</tr>
         <tr><td class="label">Description</td>${descEl}</tr>
@@ -622,6 +663,7 @@ function rMetadata (archiveInfo) {
         <tr><td class="label">Editable</td><td>${archiveInfo.isOwner}</td></tr>
       </table>
       ${archiveInfo.isOwner && isEditingInfo ? yo`<button onclick=${onSaveSettings} class="save btn">Apply changes</button>` : ''}
+      ${toolsEls}
     </div>
   `
 }
@@ -756,6 +798,25 @@ async function onUndelete (e, key) {
 
 async function onRestoreOldFolder () {
   await beaker.archives.restore(selectedArchive.key)
+  loadCurrentArchive()
+}
+
+async function onSetAutoDownload (e, value) {
+  if (selectedArchive.userSettings.autoDownload === value) {
+    return
+  }
+  selectedArchive.userSettings.autoDownload = value
+  await beaker.archives.update(selectedArchive.key, null, {autoDownload: value})
+  update()
+  toast.create('Settings updated.')
+}
+
+async function onDeleteDownloadedFiles () {
+  if (!confirm('Delete downloaded files? You will be able to redownload them from the p2p network.')) {
+    return false
+  }
+  await beaker.archives.clearFileCache(selectedArchive.key)
+  toast.create('All downloaded files have been deleted.')
   loadCurrentArchive()
 }
 

--- a/app/lib/api-manifests/internal/archives.js
+++ b/app/lib/api-manifests/internal/archives.js
@@ -9,6 +9,7 @@ export default {
   update: 'promise',
   list: 'promise',
   get: 'promise',
+  clearFileCache: 'promise',
   clearDnsCache: 'promise',
   createEventStream: 'readable',
   createDebugStream: 'readable'

--- a/app/lib/web-apis/beaker.js
+++ b/app/lib/web-apis/beaker.js
@@ -33,6 +33,7 @@ if (window.location.protocol === 'beaker:') {
   beaker.archives.update = archivesRPC.update
   beaker.archives.list = archivesRPC.list
   beaker.archives.get = archivesRPC.get
+  beaker.archives.clearFileCache = archivesRPC.clearFileCache
   beaker.archives.clearDnsCache = archivesRPC.clearDnsCache
   beaker.archives.createDebugStream = () => fromEventStream(archivesRPC.createDebugStream())
   bindEventStream(archivesRPC.createEventStream(), beaker.archives)

--- a/app/stylesheets/builtin-pages/dat-sidebar.less
+++ b/app/stylesheets/builtin-pages/dat-sidebar.less
@@ -497,6 +497,16 @@ section {
   td.label {
     width: 75px;
   }
+
+  .tools {
+    margin: 0.7rem 0.2rem;
+    padding: 1rem 0 0;
+    border-top: 1px solid @border-menu;
+
+    .link {
+      color: @color-text--muted;
+    }
+  }
 }
 
 .history-item {

--- a/app/stylesheets/builtin-pages/dat-sidebar.less
+++ b/app/stylesheets/builtin-pages/dat-sidebar.less
@@ -343,7 +343,7 @@ section {
 }
 
 .history,
-.metadata,
+.settings,
 .files-list,
 .changes {
   height: ~"calc(100vh - 175px)";
@@ -351,7 +351,7 @@ section {
 }
 
 .history,
-.metadata,
+.settings,
 .staging {
   margin: .5rem;
 }
@@ -458,7 +458,41 @@ section {
   margin: 0 .5rem;
 }
 
-.metadata {
+.settings {
+  .setting {
+    margin-bottom: 0.5rem;
+    padding: 0.25rem 0;
+
+    h5 {
+      margin-bottom: 0.25rem;
+      font-weight: 500;
+    }
+
+    fieldset {
+      border: 1px solid @border-menu;
+      background: @background-button;
+      padding: 0;
+      border-radius: 2px;
+    }
+
+    label {
+      display: block;
+      margin: 0.5rem;
+    }
+
+    .muted {
+      color: @color-text--muted;
+      font-weight: 100;
+    }
+
+    &.disabled {
+      color: @color-text--midlight;
+
+      .muted {
+        color: @color-text--light;
+      }
+    }
+  }
 
   td.label {
     width: 75px;

--- a/app/stylesheets/builtin-pages/library.less
+++ b/app/stylesheets/builtin-pages/library.less
@@ -399,7 +399,7 @@ body {
     max-width: 100%;
   }
 
-  .metadata {
+  .settings {
 
     table {
       width: 100%;
@@ -409,15 +409,15 @@ body {
       border-collapse: collapse;
       font-size: 13px;
       margin-bottom: 1rem;
+
+      input,
+      textarea {
+        width: 100%;
+      }
     }
 
     button.save {
       float: right;
-    }
-
-    input,
-    textarea {
-      width: 100%;
     }
 
     tr {
@@ -429,7 +429,7 @@ body {
       padding: 0 8px;
 
       &.label {
-        background: @background-menu;
+        background: @background-button;
         border-right: 1px solid @border-menu;
         padding-right: 5px;
         width: 125px;
@@ -442,6 +442,53 @@ body {
       cursor: pointer;
 
       &:hover {
+        color: @color-text--muted;
+      }
+    }
+
+    .setting {
+      margin-bottom: 0.5rem;
+      padding: 0.25rem 0;
+
+      h5 {
+        margin-bottom: 0.25rem;
+        font-weight: 500;
+      }
+
+      fieldset {
+        font-size: 0.8rem;
+        border: 1px solid @border-menu;
+        background: @background-button;
+        padding: 0;
+        margin: 0;
+        border-radius: 2px;
+      }
+
+      label {
+        display: block;
+        margin: 0.5rem;
+      }
+
+      .muted {
+        color: @color-text--muted;
+        font-weight: 100;
+      }
+
+      &.disabled {
+        color: @color-text--midlight;
+
+        .muted {
+          color: @color-text--light;
+        }
+      }
+    }
+
+    .tools {
+      margin: 0.7rem 0.2rem;
+      padding: 1rem 0 0;
+      border-top: 1px solid @border-menu;
+
+      .link {
         color: @color-text--muted;
       }
     }

--- a/tests/archives-web-api-test.js
+++ b/tests/archives-web-api-test.js
@@ -112,6 +112,8 @@ test('library.list', async t => {
   t.deepEqual(items.length, 2)
   t.deepEqual(items[0].userSettings.isSaved, true)
   t.deepEqual(items[1].userSettings.isSaved, true)
+  t.deepEqual(items[0].userSettings.autoDownload, true)
+  t.deepEqual(items[1].userSettings.autoDownload, true)
   t.deepEqual(items.filter(i => i.isOwner).length, 1)
 
   // list owned
@@ -157,6 +159,7 @@ test('library.get', async t => {
   }, testStaticDatURL)
   t.deepEqual(res.value.isOwner, false)
   t.deepEqual(res.value.userSettings.isSaved, false)
+  t.deepEqual(res.value.userSettings.autoDownload, true)
 })
 
 test('library "updated" event', async t => {

--- a/tests/dat-archive-web-api-test.js
+++ b/tests/dat-archive-web-api-test.js
@@ -364,8 +364,8 @@ test('DatArchive.selectArchive: create', async t => {
   await app.client.waitUntilWindowLoaded()
 
   // open the create archive view
-  await app.client.waitForExist('.tab[data-content="newArchive"]')
-  app.client.click('.tab[data-content="newArchive"]')
+  await app.client.waitForExist('.btn[data-content="newArchive"]')
+  app.client.click('.btn[data-content="newArchive"]')
 
   // input a title for a now archive
   await app.client.waitForExist('input[name="title"]')


### PR DESCRIPTION
We felt we could make the process of saving sites more clear. Instead of "Sync for offline," we now have a button to "Add to library," and then additional settings for configuring the auto-downloader.

![updated-sidebar](https://user-images.githubusercontent.com/1270099/28095372-a684c2a6-6667-11e7-8af2-87ec4f283314.gif)

We also have a UI planned for configuring auto-uploading, but this is blocked until support for no-upload is added to hypercore's replicate() method:

![uploader_todo](https://user-images.githubusercontent.com/1270099/28095400-d298381e-6667-11e7-84a1-51f0e16576bf.png)

