### PR TITLE
Deprecation: Remove createdBy and forkOf from dat.json manifests

### DIFF
--- a/app/background-process/dbs/archives.js
+++ b/app/background-process/dbs/archives.js
@@ -82,11 +82,6 @@ export async function query (profileId, query) {
   archives.forEach(archive => {
     archive.url = `dat://${archive.key}`
     archive.isOwner = archive.isOwner != 0
-    archive.createdBy = {
-      title: archive.createdByTitle,
-      url: archive.createdByUrl
-    }
-    try { archive.forkOf = JSON.parse(archive.forkOf) } catch (e) {}
     archive.userSettings = {
       isSaved: archive.isSaved != 0,
       autoDownload: archive.autoDownload != 0,
@@ -94,8 +89,6 @@ export async function query (profileId, query) {
       localPath: archive.localPath
     }
 
-    delete archive.createdByTitle
-    delete archive.createdByUrl
     delete archive.isSaved
     delete archive.autoDownload
     delete archive.autoUpload
@@ -221,9 +214,6 @@ export async function getMeta (key) {
 
     // massage some values
     meta.isOwner = !!meta.isOwner
-    try { meta.forkOf = JSON.parse(meta.forkOf) } catch (e) {}
-    meta.createdBy = {url: meta.createdByUrl, title: meta.createdByTitle}
-    delete meta.createdByUrl; delete meta.createdByTitle
     return meta
   } catch (e) {
     return {}
@@ -241,18 +231,15 @@ export async function setMeta (key, value = {}) {
   }
 
   // extract the desired values
-  var {title, description, forkOf, createdBy, mtime, metaSize, stagingSize, stagingSizeLessIgnored, isOwner} = value
+  var {title, description, mtime, metaSize, stagingSize, stagingSizeLessIgnored, isOwner} = value
   isOwner = isOwner ? 1 : 0
-  forkOf = Array.isArray(forkOf) ? JSON.stringify(forkOf) : forkOf
-  var createdByUrl = createdBy && createdBy.url ? createdBy.url : ''
-  var createdByTitle = createdBy && createdBy.title ? createdBy.title : ''
 
   // write
   await db.run(`
     INSERT OR REPLACE INTO
-      archives_meta (key, title, description, forkOf, createdByUrl, createdByTitle, mtime, metaSize, stagingSize, stagingSizeLessIgnored, isOwner)
-      VALUES        (?,   ?,     ?,           ?,      ?,            ?,              ?,     ?,        ?,           ?,                      ?)
-  `,                [key, title, description, forkOf, createdByUrl, createdByTitle, mtime, metaSize, stagingSize, stagingSizeLessIgnored, isOwner])
+      archives_meta (key, title, description, mtime, metaSize, stagingSize, stagingSizeLessIgnored, isOwner)
+      VALUES        (?,   ?,     ?,           ?,     ?,        ?,           ?,                      ?)
+  `,                [key, title, description, mtime, metaSize, stagingSize, stagingSizeLessIgnored, isOwner])
   events.emit('update:archive-meta', key, value)
 }
 

--- a/app/background-process/web-apis/archives.js
+++ b/app/background-process/web-apis/archives.js
@@ -34,28 +34,12 @@ export default {
     return status
   },
 
-  async create({title, description, createdBy}={}) {
-    // get origin info
-    if (!createdBy) {
-      createdBy = await datLibrary.generateCreatedBy(this.sender.getURL())
-    } else if (typeof createdBy === 'string') {
-      createdBy = await datLibrary.generateCreatedBy(createdBy)
-    }
-
-    // create the archive
-    return datLibrary.createNewArchive({title, description, createdBy})
+  async create({title, description} = {}) {
+    return datLibrary.createNewArchive({title, description})
   },
 
-  async fork(url, {title, description, createdBy} = {}) {
-    // get origin info
-    if (!createdBy) {
-      createdBy = await datLibrary.generateCreatedBy(this.sender.getURL())
-    } else if (typeof createdBy === 'string') {
-      createdBy = await datLibrary.generateCreatedBy(createdBy)
-    }
-
-    // create the archive
-    return datLibrary.forkArchive(url, {title, description, createdBy})
+  async fork(url, {title, description} = {}) {
+    return datLibrary.forkArchive(url, {title, description})
   },
 
   async update(url, manifestInfo, userSettings) {

--- a/app/builtin-pages/views/create-archive-modal.js
+++ b/app/builtin-pages/views/create-archive-modal.js
@@ -8,7 +8,6 @@ var archive
 // form variables
 var title = ''
 var description = ''
-var createdBy
 
 // exported api
 // =
@@ -26,7 +25,6 @@ window.setup = async function (opts) {
     var archiveInfo = archive ? archive.info : {userSettings: {}}
     title = opts.title || archiveInfo.title || ''
     description = opts.description || archiveInfo.description || ''
-    createdBy = opts.createdBy || undefined
     render()
   } catch (e) {
     console.error(e)
@@ -68,7 +66,7 @@ async function onSubmit (e) {
       await beaker.archives.update(archive.url, {title, description})
       beakerBrowser.closeModal(null, true)
     } else {
-      var newArchive = await beaker.archives.create({title, description, createdBy})
+      var newArchive = await beaker.archives.create({title, description})
       beakerBrowser.closeModal(null, {url: newArchive.url})
     }
   } catch (e) {
@@ -90,9 +88,6 @@ function render () {
   var helpText = isEditing
     ? 'Update your site\'s title and description.'
     : 'Create a new site and add it to your library.'
-  if (createdBy && !createdBy.startsWith('beaker:')) {
-    helpText = 'This page wants to ' + helpText.toLowerCase()
-  }
 
   yo.update(document.querySelector('main'), yo`<main>
     <div class="modal">

--- a/app/builtin-pages/views/fork-archive-modal.js
+++ b/app/builtin-pages/views/fork-archive-modal.js
@@ -10,7 +10,6 @@ var isProcessing = false
 // form variables
 var title = ''
 var description = ''
-var createdBy
 
 // exported api
 // =
@@ -39,7 +38,6 @@ window.setup = async function (opts) {
     var archiveInfo = archive ? archive.info : {}
     title = opts.title || archiveInfo.title || ''
     description = opts.description || archiveInfo.description || ''
-    createdBy = opts.createdBy || undefined
     render()
 
     // select and focus title input
@@ -90,7 +88,7 @@ async function onSubmit (e) {
   try {
     isProcessing = true
     render()
-    var newArchive = await beaker.archives.fork(archive.info.key, {title, description, createdBy})
+    var newArchive = await beaker.archives.fork(archive.info.key, {title, description})
     beakerBrowser.closeModal(null, {url: newArchive.url})
   } catch (e) {
     beakerBrowser.closeModal({

--- a/app/builtin-pages/views/select-archive-modal.js
+++ b/app/builtin-pages/views/select-archive-modal.js
@@ -6,7 +6,6 @@ var selectedArchiveKey = ''
 var archives
 var title = ''
 var description = ''
-var createdBy
 var buttonLabel = 'Select'
 var customTitle = ''
 var currentView = 'archivePicker'
@@ -25,8 +24,6 @@ window.setup = async function (opts) {
       isOwner: (opts.filters && opts.filters.isOwner)
     })
 
-    // render
-    createdBy = opts.createdBy || undefined
     render()
   } catch (e) {
     console.error(e)
@@ -83,7 +80,7 @@ async function onSubmit (e) {
   e.preventDefault()
   if (!selectedArchiveKey) {
     try {
-      var newArchive = await beaker.archives.create({title, description, createdBy})
+      var newArchive = await beaker.archives.create({title, description})
       beakerBrowser.closeModal(null, {url: newArchive.url})
     } catch (e) {
       beakerBrowser.closeModal({

--- a/tests/dat-archive-web-api-test.js
+++ b/tests/dat-archive-web-api-test.js
@@ -266,8 +266,6 @@ test('DatArchive.create', async t => {
   }
   t.deepEqual(manifest.title, 'The Title')
   t.deepEqual(manifest.description, 'The Description')
-  t.deepEqual(manifest.createdBy.url, testRunnerDatURL.slice(0, -1))
-  t.deepEqual(manifest.createdBy.title, 'Test Runner Dat')
 
   // check the settings
   await app.client.windowByIndex(0)
@@ -318,9 +316,6 @@ test('DatArchive.fork', async t => {
   }
   t.deepEqual(manifest.title, 'The Title')
   t.deepEqual(manifest.description, 'The Description 2')
-  t.deepEqual(manifest.createdBy.url, testRunnerDatURL.slice(0, -1))
-  t.deepEqual(manifest.createdBy.title, 'Test Runner Dat')
-  t.deepEqual(manifest.forkOf[0].replace(/(\/)$/,''), createdDatURL)
 })
 
 test('DatArchive.selectArchive rejection', async t => {
@@ -395,8 +390,6 @@ test('DatArchive.selectArchive: create', async t => {
     console.log('unexpected error parsing manifest', res.value)
   }
   t.deepEqual(manifest.title, 'The Title')
-  t.deepEqual(manifest.createdBy.url, testRunnerDatURL.slice(0, -1))
-  t.deepEqual(manifest.createdBy.title, 'Test Runner Dat')
 
   // check the settings
   await app.client.windowByIndex(0)
@@ -1041,8 +1034,6 @@ test('archive.getInfo', async t => {
   var info = res.value
   t.deepEqual(info.title, 'The Title')
   t.deepEqual(info.description, 'The Description')
-  t.deepEqual(info.createdBy.url, testRunnerDatURL.slice(0, -1))
-  t.deepEqual(info.createdBy.title, 'Test Runner Dat')
 })
 
 test('archive.download', async t => {


### PR DESCRIPTION
Closes https://github.com/beakerbrowser/beaker/issues/591 and https://github.com/beakerbrowser/beaker/issues/544

We decided this metadata offers pretty little value, but it does create the potential for accidentally leaking private information.