### PR TITLE
Expose dat.json to the staging area

### DIFF
--- a/app/background-process/protocols/dat.js
+++ b/app/background-process/protocols/dat.js
@@ -230,11 +230,6 @@ async function datServer (req, res) {
       return cb(404, 'Version too high')
     }
     archiveFS = archive.checkout(seq)
-  } else {
-    // read dat.json from archive only (never from staging)
-    if (filepath === '/' + DAT_MANIFEST_FILENAME) {
-      archiveFS = archive
-    }
   }
 
   // lookup entry

--- a/app/background-process/web-apis/dat-archive.js
+++ b/app/background-process/web-apis/dat-archive.js
@@ -375,7 +375,7 @@ function assertUnprotectedFilePath (filepath, sender) {
   if (sender.getURL().startsWith('beaker:')) {
     return // can write any file
   }
-  if (filepath === '/dat.json') {
+  if (filepath === '/' + DAT_MANIFEST_FILENAME) {
     throw new ProtectedFileNotWritableError()
   }
 }
@@ -499,12 +499,7 @@ async function lookupArchive (url, opts = {}) {
       checkin('checking out a previous version from history')
       archive.checkoutFS = archive.checkout(+version)
     } else {
-      // access dat.json from archive only (never from staging)
-      if (filepath === '/' + DAT_MANIFEST_FILENAME) {
-        archive.checkoutFS = archive
-      } else {
-        archive.checkoutFS = archive.stagingFS
-      }
+      archive.checkoutFS = archive.stagingFS
     }
 
     return {archive, filepath, version}

--- a/app/builtin-pages/com/files-list.js
+++ b/app/builtin-pages/com/files-list.js
@@ -25,8 +25,7 @@ function rFilesList (archiveInfo, opts) {
     `
   }
 
-  // this accounts for dat.json, which is hidden by default
-  var hasFiles = Object.keys(archiveInfo.fileTree.rootNode.children).length > 1
+  var hasFiles = Object.keys(archiveInfo.fileTree.rootNode.children).length > 0
   return yo`
     <div class="files-list ${!hasFiles ? 'empty' : ''}">
       ${rChildren(archiveInfo, archiveInfo.fileTree.rootNode.children, 0, opts)}
@@ -84,13 +83,6 @@ function rFolder (archiveInfo, opts) {
 function rChildren (archiveInfo, children, depth=0, opts={}) {
   var children = Object.keys(children)
     .map(key => children[key])
-    .filter(node => {
-      if (node.entry.name === 'dat.json') {
-        // hide dat.json for now
-        return false
-      }
-      return true
-    })
 
   if (children.length === 0 && depth === 0) {
     return yo`


### PR DESCRIPTION
This PR makes it so that a dat.json manifest is written to the staging area, and put into the user's attention & control.

@millette this is a change you've been asking for.