### PR TITLE
Add web_root behavior to dat hosting

### DIFF
--- a/app/background-process/networks/dat/directory-listing-page.js
+++ b/app/background-process/networks/dat/directory-listing-page.js
@@ -1,6 +1,7 @@
 import path from 'path'
 import {pluralize, makeSafe} from '../../../lib/strings'
 import {stat, readdir} from 'pauls-dat-api'
+import {join as joinPaths, relative} from 'path'
 
 const styles = `<style>
   .entry {
@@ -20,19 +21,24 @@ const styles = `<style>
   }
 </style>`
 
-export default async function renderDirectoryListingPage (archive, dirPath) {
+export default async function renderDirectoryListingPage (archive, dirPath, webRoot) {
+  // handle the webroot
+  webRoot = webRoot || '/'
+  const realPath = p => joinPaths(webRoot, p)
+  const webrootPath = p => relative(webRoot, p)
+
   // list files
   var names = []
-  try { names = await readdir(archive, dirPath) }
+  try { names = await readdir(archive, realPath(dirPath)) }
   catch (e) {}
 
   // stat each file
   var entries = await Promise.all(names.map(async (name) => {
     var entry
     var entryPath = path.join(dirPath, name)
-    try { entry = await stat(archive, entryPath) }
+    try { entry = await stat(archive, realPath(entryPath)) }
     catch (e) { return false }
-    entry.path = entryPath
+    entry.path = webrootPath(entryPath)
     entry.name = name
     return entry
   }))
@@ -49,7 +55,7 @@ export default async function renderDirectoryListingPage (archive, dirPath) {
 
   // show the updog if path is not top
   var updog = ''
-  if (dirPath !== '/' && dirPath !== '') {
+  if (['/', '', '..'].includes(webrootPath(dirPath)) === false) {
     updog = `<div class="entry updog"><a href="..">..</a></div>`
   }
 


### PR DESCRIPTION
Closes https://github.com/beakerbrowser/beaker/issues/535

You can now specify a `"web_root"` in your dat.json to control which folder beaker serves out of

![webroot-test](https://user-images.githubusercontent.com/1270099/28138992-4561718e-6718-11e7-8c1b-d479488dda99.gif)
