### PR TITLE
Fix: Correctly return a DatArchive from selectArchive

### DIFF
--- a/app/lib/web-apis/dat-archive.js
+++ b/app/lib/web-apis/dat-archive.js
@@ -191,6 +191,7 @@ export default class DatArchive extends EventTarget {
 
   static selectArchive (opts = {}) {
     return dat.selectArchive(opts)
+      .then(url => new DatArchive(url))
   }
 }
 

--- a/tests/dat-archive-web-api-test.js
+++ b/tests/dat-archive-web-api-test.js
@@ -349,7 +349,7 @@ test('DatArchive.selectArchive: create', async t => {
     // put the result on the window, for checking later
     window.res = null
     DatArchive.selectArchive({ message: 'Custom title', buttonLabel: 'button' }).then(
-      res => window.res = res,
+      res => window.res = res.url,
       err => window.res = err
     )
   })
@@ -407,7 +407,7 @@ test('DatArchive.selectArchive: select', async t => {
     // put the result on the window, for checking later
     window.res = null
     DatArchive.selectArchive().then(
-      res => window.res = res,
+      res => window.res = res.url,
       err => window.res = err
     )
   })
@@ -431,7 +431,7 @@ test('DatArchive.selectArchive: select', async t => {
   await app.client.waitUntil(() => app.client.execute(() => { return window.res != null }), 5e3)
   var res = await app.client.execute(() => { return window.res })
   t.truthy(res.value.startsWith('dat://'))
-  t.is(res.value, testRunnerDatURL)
+  t.is(res.value, testRunnerDatURL.slice(0, -1))
 })
 
 test('archive.writeFile', async t => {


### PR DESCRIPTION
The `DatArchive.selectArchive()` method is supposed to return a new DatArchive. Somehow I misimplemented it before, and returned just a `url`.

Fixing this now. Some people's apps may break (sorry!).