### PR TITLE
Make the sidebar a less front-and-center tool

### DIFF
--- a/app/shell-window/command-handlers.js
+++ b/app/shell-window/command-handlers.js
@@ -24,6 +24,7 @@ export function setup () {
       case 'view:zoom-out': return zoom.zoomOut(page)
       case 'view:zoom-reset': return zoom.zoomReset(page)
       case 'view:toggle-dev-tools': return page.toggleDevTools()
+      case 'view:open-sidebar': return sidebar.open()
       case 'view:toggle-sidebar': return sidebar.toggle()
       case 'history:back': return page.goBackAsync()
       case 'history:forward': return page.goForwardAsync()

--- a/app/shell-window/ui/navbar/dat-sidebar.js
+++ b/app/shell-window/ui/navbar/dat-sidebar.js
@@ -8,14 +8,13 @@ export class DatSidebarBtn {
   }
 
   render () {
-    if (!sidebar.getIsAvailable()) {
+    if (!sidebar.getIsAvailable() || !sidebar.getIsOpen()) {
       // hide the button
       return yo`<button class="toolbar-btn dat-sidebar btn hidden"></button>`
     }
 
-    const pressed = sidebar.getIsOpen() ? 'pressed' : ''
     return yo`
-      <button title="Toggle sidebar" class="toolbar-btn dat-sidebar btn ${pressed}" onclick=${e => this.onClickBtn(e)}>
+      <button title="Toggle sidebar" class="toolbar-btn dat-sidebar btn pressed" onclick=${e => this.onClickBtn(e)}>
         <i class="fa fa-columns"></i>
       </button>
     `

--- a/app/shell-window/ui/navbar/dat-sidebar.js
+++ b/app/shell-window/ui/navbar/dat-sidebar.js
@@ -21,11 +21,7 @@ export class DatSidebarBtn {
   }
 
   onClickBtn (e) {
-    if (sidebar.getIsOpen()) {
-      sidebar.close()
-    } else {
-      sidebar.open(pages.getActive())
-    }
+    sidebar.toggle()
     this.updateActives()
   }
 


### PR DESCRIPTION
After using the dat sidebar for a while, we decided it's handy, but really only for cases where you're doing work on a site (or inspecting the site). So we decided to model it after devtools.

Now, instead of there being a persistent navbar button, you open it with this:

![screen shot 2017-07-19 at 4 45 08 pm](https://user-images.githubusercontent.com/1270099/28390946-a8382b0c-6ca1-11e7-8afe-b75c6af1717c.png)

It also now isolates its "open" state to individual tabs, like the devtools.