### PR TITLE
Reduce false positives in diff() calls - DatArchive Staging Area

### DIFF
--- a/app/background-process/web-apis/dat-archive.js
+++ b/app/background-process/web-apis/dat-archive.js
@@ -117,7 +117,7 @@ export default {
     var {archive, version} = await lookupArchive(url, opts)
     if (version) return [] // TODO
     if (!archive.staging) return []
-    return pda.diff(archive.staging, {shallow: opts.shallow})
+    return pda.diff(archive.staging, {shallow: opts.shallow, compareContent: true})
   },
 
   async commit (url, opts = {}) {
@@ -125,7 +125,7 @@ export default {
     if (version) throw new ArchiveNotWritableError('Cannot modify a historic version')
     if (!archive.staging) return []
     await assertWritePermission(archive, this.sender)
-    var res = await pda.commit(archive.staging)
+    var res = await pda.commit(archive.staging, {compareContent: true})
     await datLibrary.updateSizeTracking(archive)
     return res
   },

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -412,9 +412,9 @@
       }
     },
     "diff-file-tree": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/diff-file-tree/-/diff-file-tree-2.1.0.tgz",
-      "integrity": "sha512-Z33nOjJnX7HmlM80Jm+DTZHHyiZVCKVL5XT8hH2KVnBGb6DqeNAcGtu/PJ2/pSmZiZuNGAvR3o4mKvX9QURLYQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/diff-file-tree/-/diff-file-tree-2.1.1.tgz",
+      "integrity": "sha512-oCj8VGfHC+o5MV5xWfuX4NFJCSosELONayvV7w378XZAQaU6nEW1CMe/IzGJ9D0Fh6xOLLKoq5p80J78kQlq4w==",
       "requires": {
         "debug": "git://github.com/beakerbrowser/debug.git#8d79a96e2c5f79527d7580960be3da9ae246ed8e",
         "es6-promisify": "5.0.0",
@@ -1773,12 +1773,12 @@
       }
     },
     "hyperdrive-staging-area": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/hyperdrive-staging-area/-/hyperdrive-staging-area-2.3.0.tgz",
-      "integrity": "sha512-NkWSySOM7kUa3IlJyA7DxzbYCN9tTtILaUbzYscMhHmFW0HophwYg52f5raKUgqvQUrgD1s7AgiuvlBSw63rvA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/hyperdrive-staging-area/-/hyperdrive-staging-area-2.4.0.tgz",
+      "integrity": "sha512-SiUNEv2aqc8x7FaL3fuEBHFWWpV62VUlsNpPOV7T4zEorWqIi+cyBy0o8tH8HA9fnIBB6M/yDTbWPI1Er78+3A==",
       "requires": {
         "anymatch": "1.3.0",
-        "diff-file-tree": "2.1.0",
+        "diff-file-tree": "2.1.1",
         "scoped-fs": "1.1.2"
       }
     },

--- a/app/package.json
+++ b/app/package.json
@@ -31,7 +31,7 @@
     "hypercore": "^6.6.3",
     "hypercore-protocol": "^6.3.1",
     "hyperdrive": "^9.4.5",
-    "hyperdrive-staging-area": "^2.3.0",
+    "hyperdrive-staging-area": "^2.4.0",
     "hyperdrive-to-zip-stream": "^2.0.0",
     "identify-filetype": "^1.0.0",
     "listen-random-port": "^1.0.0",


### PR DESCRIPTION
Currently, an archive `diff()` call will incorrectly mark some files as "changed." This occurs because the diffing algorithm only checks the 'modified time' of files to decide whether they have been changed. The modified time is updated too frequently. It is updated any time the file's content is written, which means that file-writes which do not change the actual content are still registered as "changes."

See https://twitter.com/conoro/status/890274540617641984 for the negative effects of this.

With this PR, we update the diffing algorithm to compare the full content of a file, which will remove all false-positives.

**Note**. This was tried before and it was too slow. Since then, I added the {shallow:} opt to the diffing algorithm, and I'm hopeful that will keep this algorithm performant. 

(And, yes, performant *is* a word!)