### PR TITLE
Automatically reload the page if a timedout dat is found

### DIFF
--- a/app/background-process/web-apis/dat-archive.js
+++ b/app/background-process/web-apis/dat-archive.js
@@ -350,6 +350,7 @@ export default {
   },
 
   async resolveName (name) {
+    if (DAT_HASH_REGEX.test(name)) return name
     return datDns.resolveName(name)
   },
 


### PR DESCRIPTION
This PR updates the "dat not found" behavior. When you get the "Timed out while searching" page, if Beaker finds the dat after displaying that page, it will now automatically reload the page and show the content.