### PR TITLE
Add 'quit to tray' for persistent execution

### DIFF
--- a/app/background-process.js
+++ b/app/background-process.js
@@ -76,10 +76,3 @@ app.on('ready', function () {
   // listen OSX open-url event
   openURL.setup()
 })
-
-app.on('activate', () => windows.ensureOneWindowExists())
-app.on('open-url', (e, url) => openURL.open(url))
-
-app.on('window-all-closed', function () {
-  if (process.platform !== 'darwin') { app.quit() }
-})

--- a/app/background-process/browser.js
+++ b/app/background-process/browser.js
@@ -13,6 +13,7 @@ import * as settingsDb from './dbs/settings'
 import {internalOnly} from '../lib/bg/rpc'
 import {open as openUrl} from './open-url'
 import {showModal, closeModal} from './ui/modals'
+import {setIsQuittingExplicitly} from './ui/windows'
 
 // constants
 // =
@@ -239,6 +240,7 @@ export function checkForUpdates () {
 export function restartBrowser () {
   if (updaterState == UPDATER_STATUS_DOWNLOADED) {
     // run the update installer
+    setIsQuittingExplicitly(true)
     autoUpdater.quitAndInstall()
     debug('[AUTO-UPDATE] Quitting and installing.')
   } else {

--- a/app/background-process/browser.js
+++ b/app/background-process/browser.js
@@ -13,7 +13,7 @@ import * as settingsDb from './dbs/settings'
 import {internalOnly} from '../lib/bg/rpc'
 import {open as openUrl} from './open-url'
 import {showModal, closeModal} from './ui/modals'
-import {setIsQuittingExplicitly} from './ui/windows'
+import {setIsReadyToQuit} from './ui/windows'
 
 // constants
 // =
@@ -240,7 +240,7 @@ export function checkForUpdates () {
 export function restartBrowser () {
   if (updaterState == UPDATER_STATUS_DOWNLOADED) {
     // run the update installer
-    setIsQuittingExplicitly(true)
+    setIsReadyToQuit(true)
     autoUpdater.quitAndInstall()
     debug('[AUTO-UPDATE] Quitting and installing.')
   } else {

--- a/app/background-process/ui/windows.js
+++ b/app/background-process/ui/windows.js
@@ -13,7 +13,7 @@ var userDataDir
 var stateStoreFile = 'shell-window-state.json'
 var numActiveWindows = 0
 var tray = null
-var isQuittingExplicitly = false
+var isQuittingExplicitly = process.env.NODE_ENV === 'test'
 
 // exported methods
 // =

--- a/app/background-process/ui/windows.js
+++ b/app/background-process/ui/windows.js
@@ -1,7 +1,8 @@
-import { app, BrowserWindow, screen, ipcMain, webContents } from 'electron'
+import { app, BrowserWindow, screen, ipcMain, webContents, Menu, Tray } from 'electron'
 import { register as registerShortcut, unregisterAll as unregisterAllShortcuts } from 'electron-localshortcut'
 import jetpack from 'fs-jetpack'
 import path from 'path'
+import * as openURL from '../open-url'
 import * as downloads from './downloads'
 import * as permissions from './permissions'
 var debug = require('debug')('beaker')
@@ -11,6 +12,8 @@ var debug = require('debug')('beaker')
 var userDataDir
 var stateStoreFile = 'shell-window-state.json'
 var numActiveWindows = 0
+var tray = null
+var isQuittingExplicitly = false
 
 // exported methods
 // =
@@ -18,6 +21,19 @@ var numActiveWindows = 0
 export function setup () {
   // config
   userDataDir = jetpack.cwd(app.getPath('userData'))
+
+  // setup tray
+  tray = new Tray(path.join(__dirname, './assets/img/logo-favicon.png'))
+  const contextMenu = Menu.buildFromTemplate([
+    {label: 'New Tab', click: openTab()},
+    {type: 'separator'},
+    {label: 'Library...', click: openTab('beaker://library/')},
+    {label: 'Preferences...', click: openTab('beaker://settings/')},
+    {type: 'separator'},
+    {label: 'Quit Beaker', click: explicitQuit}
+  ])
+  tray.setToolTip('Actively sharing on the p2p network.')
+  tray.setContextMenu(contextMenu)
 
   // load pinned tabs
   ipcMain.on('shell-window-ready', e => {
@@ -27,8 +43,28 @@ export function setup () {
     }
   })
 
+  // set up app events
+  app.on('activate', () => ensureOneWindowExists())
+  app.on('open-url', (e, url) => openURL.open(url))
+  app.on('before-quit', e => {
+    if (!isQuittingExplicitly) {
+      e.preventDefault()
+      // do close all windows
+      BrowserWindow.getAllWindows().forEach(w => w.close())
+    }
+  })
+
   // create first shell window
   return createShellWindow()
+}
+
+export function setIsQuittingExplicitly (v) {
+  isQuittingExplicitly = v
+}
+
+export function explicitQuit () {
+  isQuittingExplicitly = true
+  app.quit()
 }
 
 export function createShellWindow () {
@@ -111,6 +147,22 @@ export function ensureOneWindowExists () {
 function loadShell (win) {
   win.loadURL('beaker://shell-window')
   debug('Opening beaker://shell-window')
+}
+
+function openTab (location) {
+  return () => {
+    if (BrowserWindow.getAllWindows().length === 0) {
+      let win = createShellWindow()
+      if (location) {
+        ipcMain.once('shell-window-ready', () => {
+          win.webContents.send('command', 'file:new-tab', location)
+        })
+      }
+    } else {
+      let win = BrowserWindow.getFocusedWindow() || BrowserWindow.getAllWindows()[0]
+      if (win) win.webContents.send('command', 'file:new-tab', location)
+    }
+  }
 }
 
 function getCurrentPosition (win) {

--- a/app/stylesheets/shell-window/toolbar-actions.less
+++ b/app/stylesheets/shell-window/toolbar-actions.less
@@ -1,7 +1,7 @@
 .toolbar-actions {
   display: flex;
   background: @background-shell-window;
-  border-bottom: 1px solid #ddd;//@border-shell-window;
+  border-bottom: 1px solid @border-shell-window;
   padding: 5px 4px 4px 2px;
   margin: 0;
 

--- a/tests/archives-web-api-test.js
+++ b/tests/archives-web-api-test.js
@@ -13,6 +13,7 @@ const app = new Application({
   path: electron,
   args: ['../app'],
   env: {
+    NODE_ENV: 'test',
     beaker_no_welcome_tab: 1,
     beaker_user_data_path: fs.mkdtempSync(os.tmpdir() + path.sep + 'beaker-test-'),
     beaker_dat_quota_default_bytes_allowed: 1024 * 10 // 10kb

--- a/tests/browser-test.js
+++ b/tests/browser-test.js
@@ -12,6 +12,7 @@ const app = new Application({
   path: electron,
   args: ['../app'],
   env: { 
+    NODE_ENV: 'test',
     beaker_no_welcome_tab: 1,
     beaker_user_data_path: fs.mkdtempSync(os.tmpdir() + path.sep + 'beaker-test-')
   }

--- a/tests/dat-archive-web-api-test.js
+++ b/tests/dat-archive-web-api-test.js
@@ -13,6 +13,7 @@ const app = new Application({
   path: electron,
   args: ['../app'],
   env: {
+    NODE_ENV: 'test',
     beaker_no_welcome_tab: 1,
     beaker_user_data_path: fs.mkdtempSync(os.tmpdir() + path.sep + 'beaker-test-'),
     beaker_sites_path: fs.mkdtempSync(os.tmpdir() + path.sep + 'beaker-test-'),


### PR DESCRIPTION
This PR updates Beaker so that it minimizes to the tray by default, rather than quitting. This keeps people's files online more reliably.

![screen shot 2017-08-10 at 7 13 19 pm](https://user-images.githubusercontent.com/1270099/29197304-02a186aa-7e00-11e7-936a-07a9588ca850.png)

Closes #650