### PR TITLE
select the title input when opening the bookmark menu dropdown

### DIFF
--- a/app/shell-window/ui/navbar/bookmark-menu.js
+++ b/app/shell-window/ui/navbar/bookmark-menu.js
@@ -162,8 +162,11 @@ export class BookmarkMenuNavbarBtn {
 
     this.updateActives()
 
-    // focus the title input
-    document.querySelectorAll('.bookmark-title').forEach(el => el.focus())
+    // select the title input
+    document.querySelectorAll('.bookmark-title').forEach(el => {
+      el.focus()
+      el.select()
+    })
   }
 
   async onSaveBookmark (e) {


### PR DESCRIPTION
I'm wondering if this could be a good change. Other browsers such as Chrome and Firefox seem to have this behavior (when you click to edit a bookmark, the title is automatically selected). It's a very minor change, but I've been thinking about it every time I open the bookmark menu dropdown, so I figured it might be a good idea to do a pull request 😛 

<img width="359" alt="screen shot 2017-09-20 at 12 35 03 am" src="https://user-images.githubusercontent.com/1114844/30627049-f8f099d2-9d9b-11e7-94ec-8f8372764ae1.png">

<img width="308" alt="screen shot 2017-09-20 at 12 35 29 am" src="https://user-images.githubusercontent.com/1114844/30627052-fa4fd6da-9d9b-11e7-8552-53cd4408b629.png">
