### PR TITLE
(Beaker 0.8) tab shortcuts

### DIFF
--- a/app/background-process/ui/windows.js
+++ b/app/background-process/ui/windows.js
@@ -97,7 +97,8 @@ export function createShellWindow () {
   numActiveWindows++
 
   // register shortcuts
-  for (var i = 1; i <= 9; i++) { registerShortcut(win, 'CmdOrCtrl+' + i, onTabSelect(win, i - 1)) }
+  for (var i = 1; i <= 8; i++) { registerShortcut(win, 'CmdOrCtrl+' + i, onTabSelect(win, i - 1)) }
+  registerShortcut(win, 'CmdOrCtrl+9', onLastTab(win))
   registerShortcut(win, 'Ctrl+Tab', onNextTab(win))
   registerShortcut(win, 'Ctrl+Shift+Tab', onPrevTab(win))
   registerShortcut(win, 'Ctrl+PageUp', onNextTab(win))
@@ -244,6 +245,10 @@ function onClose (win) {
 
 function onTabSelect (win, tabIndex) {
   return () => win.webContents.send('command', 'set-tab', tabIndex)
+}
+
+function onLastTab (win) {
+  return () => win.webContents.send('command', 'window:last-tab')
 }
 
 function onNextTab (win) {

--- a/app/background-process/ui/windows.js
+++ b/app/background-process/ui/windows.js
@@ -100,6 +100,8 @@ export function createShellWindow () {
   for (var i = 1; i <= 9; i++) { registerShortcut(win, 'CmdOrCtrl+' + i, onTabSelect(win, i - 1)) }
   registerShortcut(win, 'Ctrl+Tab', onNextTab(win))
   registerShortcut(win, 'Ctrl+Shift+Tab', onPrevTab(win))
+  registerShortcut(win, 'Ctrl+PageUp', onNextTab(win))
+  registerShortcut(win, 'Ctrl+PageDown', onPrevTab(win))
   registerShortcut(win, 'CmdOrCtrl+[', onGoBack(win))
   registerShortcut(win, 'CmdOrCtrl+]', onGoForward(win))
   registerShortcut(win, 'CmdOrCtrl+N', onNewWindow(win))

--- a/app/shell-window/command-handlers.js
+++ b/app/shell-window/command-handlers.js
@@ -29,6 +29,7 @@ export function setup () {
       case 'bookmark:create': return navbar.bookmarkAndOpenMenu()
       case 'window:next-tab': return pages.changeActiveBy(1)
       case 'window:prev-tab': return pages.changeActiveBy(-1)
+      case 'window:last-tab': return pages.changeActiveToLast()
       case 'set-tab': return pages.changeActiveTo(arg1)
       case 'load-pinned-tabs': return pages.loadPinnedFromDB()
       case 'perms:prompt': return permsPrompt(arg1, arg2, arg3, arg4)

--- a/app/shell-window/pages.js
+++ b/app/shell-window/pages.js
@@ -434,6 +434,10 @@ export function changeActiveTo (index) {
   if (index >= 0 && index < pages.length) { setActive(pages[index]) }
 }
 
+export function changeActiveToLast () {
+  setActive(pages[pages.length-1])
+}
+
 export function getActive () {
   return activePage
 }


### PR DESCRIPTION
this adds two shortcuts I have muscle memory around from other browser : 
- `ctrl` + `PageDown` to go to the next tab  ( `PageUp` is prev tab)
- `ctrl` + `9` to go to the last tab