### PR TITLE
add fullscreen options for youtube etc

### DIFF
--- a/app/background-process/ui/window-menu.js
+++ b/app/background-process/ui/window-menu.js
@@ -194,11 +194,13 @@ export function buildWindowMenu (opts = {}) {
       label: 'Advanced Tools',
       submenu: [{
         label: 'Reload Shell-Window',
+        accelerator: 'CmdOrCtrl+alt+shift+R',
         click: function () {
           BrowserWindow.getFocusedWindow().webContents.reloadIgnoringCache()
         }
       }, {
         label: 'Toggle Shell-Window DevTools',
+        accelerator: 'CmdOrCtrl+alt+shift+I',
         click: function () {
           BrowserWindow.getFocusedWindow().toggleDevTools()
         }

--- a/app/background-process/ui/windows.js
+++ b/app/background-process/ui/windows.js
@@ -79,7 +79,8 @@ export function createShellWindow () {
   var { x, y, width, height } = ensureVisibleOnSomeDisplay(restoreState())
   var win = new BrowserWindow({
     titleBarStyle: 'hidden-inset',
-    fullscreenable: false,
+    autoHideMenuBar: true,
+    fullscreenable: true,
     x,
     y,
     width,
@@ -106,6 +107,7 @@ export function createShellWindow () {
   registerShortcut(win, 'CmdOrCtrl+Q', onQuit(win))
   registerShortcut(win, 'CmdOrCtrl+T', onNewTab(win))
   registerShortcut(win, 'CmdOrCtrl+W', onCloseTab(win))
+  registerShortcut(win, 'Esc', onEscape(win))
 
   // register event handlers
   win.on('scroll-touch-begin', sendScrollTouchBegin)
@@ -274,6 +276,10 @@ function onNewTab (win) {
 
 function onCloseTab (win) {
   return () => win.webContents.send('command', 'file:close-tab')
+}
+
+function onEscape (win) {
+  return () => win.webContents.send('window-event', 'leave-full-screen')
 }
 
 // window event handlers

--- a/app/shell-window/ui.js
+++ b/app/shell-window/ui.js
@@ -43,7 +43,7 @@ export function setup (cb) {
 
 function onWindowEvent (event, type) {
   switch (type) {
-    case 'blur': return docuument.body.classList.add('window-blurred')
+    case 'blur': return document.body.classList.add('window-blurred')
     case 'focus':
       document.body.classList.remove('window-blurred')
       try { pages.getActive().webviewEl.focus() } catch (e) {}

--- a/app/shell-window/ui.js
+++ b/app/shell-window/ui.js
@@ -42,11 +42,14 @@ export function setup (cb) {
 }
 
 function onWindowEvent (event, type) {
-  if (type == 'blur') { document.body.classList.add('window-blurred') }
-  if (type == 'focus') {
-    document.body.classList.remove('window-blurred')
-    try { pages.getActive().webviewEl.focus() } catch (e) {}
+  switch (type) {
+    case 'blur': return docuument.body.classList.add('window-blurred')
+    case 'focus':
+      document.body.classList.remove('window-blurred')
+      try { pages.getActive().webviewEl.focus() } catch (e) {}
+      break
+    case 'enter-full-screen': return document.body.classList.add('fullscreen')
+    case 'leave-full-screen': return document.body.classList.remove('fullscreen') 
   }
-  if (type == 'enter-full-screen') { document.body.classList.add('fullscreen') }
-  if (type == 'leave-full-screen') { document.body.classList.remove('fullscreen') }
 }
+

--- a/app/stylesheets/shell-window/toolbar.less
+++ b/app/stylesheets/shell-window/toolbar.less
@@ -21,6 +21,10 @@ body.darwin #toolbar {
   -webkit-app-region: drag;
 }
 
+body.fullscreen #toolbar {
+  display: none;
+}
+
 .download-started-animation {
   position: fixed;
   bottom: 20px;
@@ -56,3 +60,4 @@ body.darwin #toolbar {
     }
   }
 }
+

--- a/app/stylesheets/shell-window/webviews.less
+++ b/app/stylesheets/shell-window/webviews.less
@@ -25,3 +25,8 @@
     }
   }
 }
+
+body.fullscreen #webviews {
+  height: 100%;
+}
+


### PR DESCRIPTION
I'm trying to use Beaker as my default browser. I was watching this excellent critique on masculinity in film :
 
[![selection_400](https://user-images.githubusercontent.com/2665886/30729657-5c722726-9fb5-11e7-9982-7dbba07300ca.png)](https://www.youtube.com/watch?v=C4kuR1gyOeQ)*https://www.youtube.com/watch?v=C4kuR1gyOeQ*

But couldn't watch it fullscreen :crying_cat_face: _(blocked fullscreen / needy tabs + nav wanting to join the party)_

This PR aims to rectify that. Works well on Linux. Things that might still need attention : 
- what does this do on darwin?
- Hitting `Esc` while watching a video doesn't yet exit fullscreen mode, but it does get you your tabs + nav back.
