### PR TITLE
add keyboard shortcust for shell window dev

### DIFF
--- a/app/background-process/ui/window-menu.js
+++ b/app/background-process/ui/window-menu.js
@@ -194,11 +194,13 @@ export function buildWindowMenu (opts = {}) {
       label: 'Advanced Tools',
       submenu: [{
         label: 'Reload Shell-Window',
+        accelerator: 'CmdOrCtrl+alt+shift+R',
         click: function () {
           BrowserWindow.getFocusedWindow().webContents.reloadIgnoringCache()
         }
       }, {
         label: 'Toggle Shell-Window DevTools',
+        accelerator: 'CmdOrCtrl+alt+shift+I',
         click: function () {
           BrowserWindow.getFocusedWindow().toggleDevTools()
         }


### PR DESCRIPTION
I didn't know you could reload the shell-window without rebuilding :japanese_goblin: :sweat_drops: 

I guess I should have looked for or asked for advice on dev flow in this app.
Anyway, this adds shortcuts for accessing what I need to access right now. 