### PR TITLE
Save window state if the window is maximized, but not if it's in fullscreen mode

### DIFF
--- a/app/background-process/ui/windows.js
+++ b/app/background-process/ui/windows.js
@@ -244,7 +244,7 @@ function onClose (win) {
     // save state
     // NOTE this is called by .on('close')
     // if quitting multiple windows at once, the final saved state is unpredictable
-    if (!win.isMinimized() && !win.isMaximized()) {
+    if (!win.isMinimized() && !win.isFullScreen()) {
       var state = getCurrentPosition(win)
       userDataDir.write(stateStoreFile, state, { atomic: true })
     }


### PR DESCRIPTION
For a while, I've noticed that Beaker doesn't remember the window state when I resize the browser window to take the full width of my screen (in other words, when I maximize it). I have a large display with a resolution of 2048 by 1152, and by default, Beaker sets the width of the browser window to 1800 pixels (because of [this line](https://github.com/beakerbrowser/beaker/blob/7ee2e867f0dfc30a4e1c7ba81886fd7f88641e00/app/background-process/ui/windows.js#L211)).

After digging in the source code a bit, I noticed that Beaker doesn't save the window state if the browser window is maximized (see [this line](https://github.com/beakerbrowser/beaker/blob/7ee2e867f0dfc30a4e1c7ba81886fd7f88641e00/app/background-process/ui/windows.js#L247)). So this explains the issue I am having.

Instead of not saving the window state if the browser window is maximized, maybe it should not save it if the browser window is in fullscreen mode?

Let me know what you think 🙂 Cheers!