### PR TITLE
Add onContextMenu to locationInput

### DIFF
--- a/app/shell-window/ui/navbar.js
+++ b/app/shell-window/ui/navbar.js
@@ -297,6 +297,7 @@ function render (id, page) {
     <input
       type="text"
       class="nav-location-input ${(!isAddrElFocused) ? ' hidden' : ''}"
+      oncontextmenu=${onContextMenu}
       onfocus=${onFocusLocation}
       onblur=${onBlurLocation}
       onkeydown=${onKeydownLocation}
@@ -706,4 +707,14 @@ function onKeydownFind (e) {
       else page.stopFindInPageAsync('clearSelection')
     }
   }
+}
+
+function onContextMenu (e) {
+  const { Menu } = remote
+  const menu = [
+    { label: 'Cut', role: 'cut' },
+    { label: 'Copy', role: 'copy' },
+    { label: 'Paste', role: 'paste' }
+  ]
+  Menu.buildFromTemplate(menu).popup()
 }


### PR DESCRIPTION
@pfrazee going after some low handing fruit...

Added a right click context so you can `cut`, `copy`, `paste` in `locationInput`:

![contextmenu](https://user-images.githubusercontent.com/675259/31848688-8d9a1a5a-b605-11e7-85b0-39277eb4b6c5.gif)
