### PR TITLE
Fix URL typing interruption

### DIFF
--- a/app/shell-window/pages.js
+++ b/app/shell-window/pages.js
@@ -495,7 +495,7 @@ function onDomReady (e) {
     if (!page.wcID) {
       page.wcID = e.target.getWebContents().id // NOTE: this is a sync op
     }
-    if (!navbar.isLocationFocused(page)) {
+    if (!navbar.isLocationFocused(page) && page.isActive) {
       page.webviewEl.shadowRoot.querySelector('object').focus()
     }
   }


### PR DESCRIPTION
Fix issue reported by @taravancil (https://github.com/beakerbrowser/beaker/issues/671) that prevented URL from keeping active when other pages finished loading.