### PR TITLE
add minimal ad-blocker

### DIFF
--- a/app/background-process/ui/permissions.js
+++ b/app/background-process/ui/permissions.js
@@ -1,4 +1,5 @@
 import { ipcMain, session, BrowserWindow } from 'electron'
+import { initialize, isAd } from 'is-ad'
 import * as siteData from '../dbs/sitedata'
 import PERMS from '../../lib/perms'
 import { getPermId } from '../../lib/strings'
@@ -13,6 +14,21 @@ var activeRequests = []
 // =
 
 export function setup () {
+  // block ads
+  initialize() // is-ad
+
+  const beakerUrls =  /^(beaker|blob)/
+  session.defaultSession.webRequest.onBeforeRequest(['*://*./*'], (details, callback) => {
+    const shouldBeBlocked = !details.url.match(beakerUrls) && isAd(details.url)
+
+    if (shouldBeBlocked) {
+      console.log('ADBLOCKER', details)
+      callback({cancel: true})
+    } else {
+      callback({cancel: false})
+    }
+  })
+
   // wire up handlers
   session.defaultSession.setPermissionRequestHandler(onPermissionRequestHandler)
   ipcMain.on('permission-response', onPermissionResponseHandler)

--- a/app/package.json
+++ b/app/package.json
@@ -42,6 +42,7 @@
     "hyperdrive-to-zip-stream": "^2.0.0",
     "identify-filetype": "^1.0.0",
     "ingestdb": "^2.4.7",
+    "is-ad": "^0.1.0",
     "listen-random-port": "^1.0.0",
     "lodash": "^4.17.2",
     "lodash.groupby": "^4.6.0",


### PR DESCRIPTION
I wanted an adblocker for sites and for youtube.
This seems to work, but the code is sitting in the wrong place :man_shrugging: (TODO)

| Before | After | 
|:---:|:---:|
| ![selection_423](https://user-images.githubusercontent.com/2665886/32401442-77aab4e2-c173-11e7-9bda-b32c0145ae2b.png) | ![selection_424](https://user-images.githubusercontent.com/2665886/32401444-7eed5746-c173-11e7-98bb-a518d93262ad.png) | 

I think this also blocks **youtube ads** phew

## Research

I cast around for simple setups, here's a reference of what I found for posterity: 
- https://electron.atom.io/docs/api/web-request/ - how to intercede
- https://www.npmjs.com/package/is-ad (<< using this)
- brave's setup : 
  - https://github.com/brave/ad-block bad documention
  - browser adblock initialisation : [/app/adBlock.js](https://github.com/brave/browser-laptop/blob/c9c7fbaa0998ad5e90de4f6f45cbf954f80eef90/app/adBlock.js)
  - utils called by that initialisation : [/app/browser/ads/adBlockUtil.js](https://github.com/brave/browser-laptop/blob/560f997ccb8f187c82ddf6c1dc7d22c152f85a94/app/browser/ads/adBlockUtil.js)