### PR TITLE
Render swarm debugger error in view

### DIFF
--- a/app/builtin-pages/views/swarm-debugger.js
+++ b/app/builtin-pages/views/swarm-debugger.js
@@ -10,7 +10,13 @@ var peers = []
 
 setup()
 async function setup () {
-  archiveKey = await parseURL()
+  try {
+    archiveKey = await parseURL()
+  } catch (e) {
+    renderUsage(e.message)
+    return
+  }
+
   render()
   updatePeers()
 
@@ -76,6 +82,15 @@ function updatePeers () {
   })}
       ${peers.length === 0 ? yo`<p>No peers are currently connected for this archive.</p>` : ''}
     </div>
+  `)
+}
+
+function renderUsage (err) {
+  yo.update(document.querySelector('main'), yo`
+    <main>
+      <h1>${err}</h1>
+      <h2>A valid dat URL is required in the URL path.</h2>
+    </main>
   `)
 }
 


### PR DESCRIPTION
I added an error message to the view when parsing the URL fails. Normally the view renders a blank screen when this error occurs.

<img width="412" alt="screen shot 2018-01-11 at 8 31 43 pm" src="https://user-images.githubusercontent.com/1656324/34855618-b6854486-f70e-11e7-97ad-323269111bf2.png">
