### PR TITLE
Prevent inconsistent white background body applied to body

### DIFF
--- a/app/shell-window/pages.js
+++ b/app/shell-window/pages.js
@@ -686,7 +686,7 @@ function onDidStopLoading (e) {
       // set the default background to white.
       // on some devices, if no bg is set, the buffer doesnt get cleared
       `body {
-        background: #fff;
+        background: rgba(0,0,0,0.0);
       }` +
 
       // style file listings


### PR DESCRIPTION
Injecting a fully transparent background color instead of white resolves issue #817.