### PR TITLE
[WIP] Restore Window State on Crash

### DIFF
--- a/app/background-process/open-url.js
+++ b/app/background-process/open-url.js
@@ -5,7 +5,7 @@ var queue = []
 var isLoaded = false
 
 export function setup () {
-  ipcMain.on('shell-window-ready', function (e) {
+  ipcMain.on('shell-window:ready', function (e) {
     queue.forEach(url => e.sender.send('command', 'file:new-tab', url))
     queue.length = 0
     isLoaded = true

--- a/app/shell-window.js
+++ b/app/shell-window.js
@@ -6,5 +6,5 @@ import beaker from './lib/web-apis/beaker'
 window.DatArchive = DatArchive
 window.beaker = beaker
 setupUI(() => {
-  ipcRenderer.send('shell-window-ready')
+  ipcRenderer.send('shell-window:ready')
 })

--- a/app/shell-window/command-handlers.js
+++ b/app/shell-window/command-handlers.js
@@ -8,6 +8,7 @@ export function setup () {
   ipcRenderer.on('command', function (event, type, arg1, arg2, arg3, arg4) {
     var page = pages.getActive()
     switch (type) {
+      case 'initialize': return pages.initializeFromSnapshot(arg1)
       case 'file:new-tab':
         page = pages.create(arg1)
         pages.setActive(page)

--- a/app/shell-window/ui.js
+++ b/app/shell-window/ui.js
@@ -44,14 +44,16 @@ export function setup (cb) {
   commandHandlers.setup()
   swipeHandlers.setup()
   pages.setup()
-  pages.setActive(pages.create(pages.FIRST_TAB_URL))
-  cb()
+  ipcRenderer.send('shell-window:pages-ready')
+  pages.on('first-page', cb)
 }
+
 
 function onWindowEvent (event, type) {
   switch (type) {
     case 'blur': return document.body.classList.add('window-blurred')
     case 'focus':
+      console.log('[ipc] window-event (focus)')
       document.body.classList.remove('window-blurred')
       try { pages.getActive().webviewEl.focus() } catch (e) {}
       break


### PR DESCRIPTION
**Do Not Merge** This is a work-in-progress pull request to fix #737. Right now this branch just always restores the previous window state. I still need to make sure that this only happens on crash. Would also probably want to bring up a prompt to ask if they want to restore state. I know some browsers also have a "Restore tabs from last time" setting to have this always trigger, so I'm not sure if I should try to sneak that into this pull request as well. Mainly I want to get the code in front of y'all to see if you have any feedback on the approach. Just want to see if I'm on the right track here. Please feel free to ignore any `console.log` statements I'll try to remove those before all's said and done.

![window-state-example](https://user-images.githubusercontent.com/916253/35892853-e2521e2e-0b70-11e8-9523-201f9a8a7d1e.gif)