### PR TITLE
Add setting to always restore previouslly opened tabs.

### DIFF
--- a/app/background-process/dbs/settings.js
+++ b/app/background-process/dbs/settings.js
@@ -12,6 +12,7 @@ var setupPromise
 
 const DEFAULT_SETTINGS = {
   auto_update_enabled: 1,
+  custom_start_page: 'blank',
   start_page_background_image: '',
   workspace_default_path: path.join(app.getPath('home'), 'Sites')
 }

--- a/app/background-process/ui/windows.js
+++ b/app/background-process/ui/windows.js
@@ -8,6 +8,7 @@ import path from 'path'
 import * as openURL from '../open-url'
 import * as downloads from './downloads'
 import * as permissions from './permissions'
+import * as settingsDb from '../dbs/settings'
 
 const IS_WIN = process.platform === 'win32'
 
@@ -23,7 +24,7 @@ const ICON_PATH = path.join(__dirname, (process.platform === 'win32') ? './asset
 // exported methods
 // =
 
-export function setup () {
+export async function setup () {
   // config
   userDataDir = jetpack.cwd(app.getPath('userData'))
 
@@ -63,8 +64,9 @@ export function setup () {
 
   let previousSessionState = getPreviousBrowsingSession()
   sessionWatcher = new SessionWatcher(userDataDir)
+  let customStartPage = await settingsDb.get('custom_start_page')
 
-  if (!previousSessionState.cleanExit && userWantsToRestoreSession()) {
+  if (customStartPage === 'previous' || !previousSessionState.cleanExit && userWantsToRestoreSession()) {
     restoreBrowsingSession(previousSessionState)
   } else {
     // use the last session's window position

--- a/app/builtin-pages/views/settings.js
+++ b/app/builtin-pages/views/settings.js
@@ -120,6 +120,7 @@ function renderGeneral () {
   return yo`
     <div class="view">
       ${renderWorkspacePathSettings()}
+      ${renderOnStartupSettings()}
       ${renderAutoUpdater()}
       ${renderProtocolSettings()}
     </div>
@@ -141,6 +142,29 @@ function renderWorkspacePathSettings () {
           Choose directory
         </button>
       </p>
+    </div>
+  `
+}
+
+function renderOnStartupSettings () {
+  return yo`
+    <div class="section on-startup">
+      <h2 id="on-startup" class="subtitle-heading">On Startup</h2>
+
+      <p>When Beaker starts what do you want to see?</p>
+
+      <div class="radio-group">
+        <input type="radio" id="customStartPage1" name="custom-start-page"
+               value="blank"
+               checked=${settings.custom_start_page === "blank"}
+               onchange=${onCustomStartPageChange} />
+        <label for="customStartPage1">Show a blank page</label>
+        <input type="radio" id="customStartPage2" name="custom-start-page"
+               value="previous"
+               checked=${settings.custom_start_page === "previous"}
+               onchange=${onCustomStartPageChange} />
+        <label for="customStartPage2">Show my previously opened tabs</label>
+      </div>
     </div>
   `
 }
@@ -330,6 +354,11 @@ function renderAutoUpdateCheckbox () {
 function onUpdateView (view) {
   activeView = view
   renderToPage()
+}
+
+function onCustomStartPageChange (e) {
+  settings.custom_start_page = e.target.value
+  beaker.browser.setSetting('custom_start_page', settings.custom_start_page)
 }
 
 function onClickCheckUpdates () {

--- a/app/stylesheets/builtin-pages/settings.less
+++ b/app/stylesheets/builtin-pages/settings.less
@@ -129,6 +129,18 @@ ul.settings-section {
   border-radius:  2px;
 }
 
+.section.on-startup {
+  .radio-group {
+    display: grid;
+    grid-template-columns: auto auto;
+    align-items: end;
+    justify-content: start;
+    grid-gap: 0 5px;
+    margin-left: @padding-component--tight;
+    input[type="radio"] { margin-top: 0; }
+  }
+}
+
 .settings-section.applications {
 
   .create-app {


### PR DESCRIPTION
This pull request adds the **"General"** settings page that includes an **"On Startup"** option that lets users choose what pages to display on startup. You can either choose to open up a blank page (the default) or you can open up your previously opened tabs and windows. This is an extension of the work done in #840. This should resolve issue #737. This PR adds a new `custom_start_page` setting to make it work.

@taravancil I'm guessing you might have an opinion on the page name and placement of this setting. I just went with a "General" page because that's where I saw this setting located in other browsers, but if you want it moved let me know.

(p.s. It seems the Settings page navigation is hidden at the moment on the 0.8 branch. Something to do with the absolute positioning?) 
