### PR TITLE
Implemented mouse browser back/forward navigation (Windows only :c)

### DIFF
--- a/app/background-process/ui/windows.js
+++ b/app/background-process/ui/windows.js
@@ -74,6 +74,8 @@ export function createShellWindow () {
   registerShortcut(win, 'CmdOrCtrl+]', onGoForward(win))
 
   // register event handlers
+  win.on('browser-backward', onGoBack(win))
+  win.on('browser-forward', onGoForward(win))
   win.on('scroll-touch-begin', sendScrollTouchBegin)
   win.on('scroll-touch-end', sendToWebContents('scroll-touch-end'))
   win.on('focus', sendToWebContents('focus'))

--- a/app/background-process/ui/windows.js
+++ b/app/background-process/ui/windows.js
@@ -74,8 +74,6 @@ export function createShellWindow () {
   registerShortcut(win, 'CmdOrCtrl+]', onGoForward(win))
 
   // register event handlers
-  win.on('browser-backward', onGoBack(win))
-  win.on('browser-forward', onGoForward(win))
   win.on('scroll-touch-begin', sendScrollTouchBegin)
   win.on('scroll-touch-end', sendToWebContents('scroll-touch-end'))
   win.on('focus', sendToWebContents('focus'))
@@ -83,6 +81,7 @@ export function createShellWindow () {
   win.on('enter-full-screen', sendToWebContents('enter-full-screen'))
   win.on('leave-full-screen', sendToWebContents('leave-full-screen'))
   win.on('close', onClose(win))
+  win.on('app-command', (e, cmd) => {onAppCommand(win, e, cmd)})
 
   return win
 }
@@ -227,6 +226,21 @@ function onGoBack (win) {
 
 function onGoForward (win) {
   return () => win.webContents.send('command', 'history:forward')
+}
+
+function onAppCommand(win, e, cmd) {
+  // handles App Command events (Windows)
+  // see https://electronjs.org/docs/all#event-app-command-windows
+  switch (cmd) {
+    case 'browser-backward':
+      win.webContents.send('command', 'history:back')
+      break
+    case 'browser-forward':
+      win.webContents.send('command', 'history:forward')
+      break
+    default:
+      break
+  }
 }
 
 // window event handlers


### PR DESCRIPTION
This PR adds and registers a new event handler function for handling App Commands emitted by a Windows OS. Only the 'browser-backward' and 'browser-forward' commands are being handled by this code. When either are handled, the appropriate calls are made to navigate forward or backward in browsing history. 