### PR TITLE
add a keyboard shortcut to preferences on mac

### DIFF
--- a/app/background-process/ui/window-menu.js
+++ b/app/background-process/ui/window-menu.js
@@ -7,6 +7,7 @@ var darwinMenu = {
   submenu: [
     {
       label: 'Preferences',
+      accelerator: 'Command+,',
       click (item, win) {
         if (win) win.webContents.send('command', 'file:new-tab', 'beaker://settings')
       }


### PR DESCRIPTION
Open preferences with <kbd>Cmd</kbd><kbd>,</kbd> on macOS

<img width="258" alt="screen shot 2018-02-18 at 1 07 20 pm" src="https://user-images.githubusercontent.com/2289/36356836-c180fb12-14ac-11e8-8c89-d1f53bff9f7f.png">
