### PR TITLE
Fix running beakerbrowser outside the repo

### DIFF
--- a/tasks/start-cli.js
+++ b/tasks/start-cli.js
@@ -4,13 +4,16 @@ const NODE_FLAGS = `--js-flags="--throw-deprecation"`
 
 var childProcess = require('child_process')
 var electron = require('electron')
+var path = require('path')
+
+var app = path.join(__dirname, '../app')
 
 module.exports = function () {
   if (process.env.ELECTRON_PATH) {
     electron = process.env.ELECTRON_PATH
   }
   console.log('Spawning electron', electron)
-  childProcess.spawn(electron, [NODE_FLAGS, './app'], {
+  childProcess.spawn(electron, [NODE_FLAGS, app], {
     stdio: 'inherit',
     env: process.env // inherit
   })


### PR DESCRIPTION
After this fix you can run `beakerbrowser` anywhere on your machine to launch it after npm linking