### PR TITLE
Fix typo in onboarding-popup

### DIFF
--- a/app/builtin-pages/com/onboarding-popup.js
+++ b/app/builtin-pages/com/onboarding-popup.js
@@ -14,7 +14,7 @@ const STEPS = [
   {
     title: 'Welcome to Beaker!',
     subtitle: 'Configure your preferences',
-    description: 'Beaker is browser for exploring and building the peer-to-peer Web.',
+    description: 'Beaker is a browser for exploring and building the peer-to-peer Web.',
     content: () => yo`
       <div>
         <img class="icon" src="beaker://assets/img/onboarding/p2p-connection.svg" />


### PR DESCRIPTION
I assume "is a browser" was intended, not "is browser". Feel free to close if that wasn't the case.

Good job, folks! It's looking sharp 👌 