### PR TITLE
Added DuckDuckGo search to context menu

### DIFF
--- a/app/background-process/ui/context-menu.js
+++ b/app/background-process/ui/context-menu.js
@@ -151,6 +151,18 @@ export default function registerContextMenu () {
         menuItems.push({ type: 'separator' })
       }
 
+      // web search 
+      if(hasText){
+        var searchPreviewStr = props.selectionText.substr(0,30) // Trim search preview to keep it reasonably sized
+        if (searchPreviewStr.length < props.selectionText.length){ // Add ellipsis if search preview was trimmed
+          searchPreviewStr += '...\"'
+        } else {
+          searchPreviewStr += '\"'
+        }
+        menuItems.push({ label: 'Search DuckDuckGo for \"' + searchPreviewStr, click: (item, win) => win.webContents.send('command', 'file:new-tab', 'https://duckduckgo.com/?q='+props.selectionText) })
+        menuItems.push({ type: 'separator' })
+      }
+
       if (!props.linkURL && props.mediaType === 'none' && !hasText) {
         menuItems.push({
           label: 'Back',

--- a/app/background-process/ui/context-menu.js
+++ b/app/background-process/ui/context-menu.js
@@ -154,7 +154,8 @@ export default function registerContextMenu () {
       // web search
       if(hasText){
         var searchPreviewStr = props.selectionText.substr(0,30) // Trim search preview to keep it reasonably sized
-        searchPreviewStr = searchPreviewStr.replace(/\s/gi, ' ');
+        searchPreviewStr = searchPreviewStr.replace(/\s/gi, ' ') // Replace whitespace chars with space
+        searchPreviewStr = searchPreviewStr.replace(/[\u061c\u200E\u200f\u202A-\u202E]+/g, '') // Remove directional text control chars
         if (searchPreviewStr.length < props.selectionText.length){ // Add ellipsis if search preview was trimmed
           searchPreviewStr += '...\"'
         } else {

--- a/app/background-process/ui/context-menu.js
+++ b/app/background-process/ui/context-menu.js
@@ -160,7 +160,8 @@ export default function registerContextMenu () {
         } else {
           searchPreviewStr += '\"'
         }
-        menuItems.push({ label: 'Search DuckDuckGo for \"' + searchPreviewStr, click: (item, win) => win.webContents.send('command', 'file:new-tab', 'https://duckduckgo.com/?q='+props.selectionText) })
+        var query = 'https://duckduckgo.com/?q=' + props.selectionText.substr(0,500) // Limit query to prevent too long query error from DDG
+        menuItems.push({ label: 'Search DuckDuckGo for \"' + searchPreviewStr, click: (item, win) => win.webContents.send('command', 'file:new-tab', query) })
         menuItems.push({ type: 'separator' })
       }
 

--- a/app/background-process/ui/context-menu.js
+++ b/app/background-process/ui/context-menu.js
@@ -151,9 +151,10 @@ export default function registerContextMenu () {
         menuItems.push({ type: 'separator' })
       }
 
-      // web search 
+      // web search
       if(hasText){
         var searchPreviewStr = props.selectionText.substr(0,30) // Trim search preview to keep it reasonably sized
+        searchPreviewStr = searchPreviewStr.replace(/\s/gi, ' ');
         if (searchPreviewStr.length < props.selectionText.length){ // Add ellipsis if search preview was trimmed
           searchPreviewStr += '...\"'
         } else {


### PR DESCRIPTION
In Chrome and Firefox you can highlight some text in a webpage, right-click it, and search Google for that text. I missed that feature so I implemented it for searching DuckDuckGo. 

It works for non-editable text...
![image](https://user-images.githubusercontent.com/10363350/37561494-2f3a7a6e-2a26-11e8-9b4f-7529580b1a11.png)
and editable text
![image](https://user-images.githubusercontent.com/10363350/37561521-981b5e68-2a26-11e8-9386-7ee0609d54f4.png)

and doesn't appear if you haven't selected and right-clicked some text.