### PR TITLE
Show browser history shortcut in dropdown menu by platform:

### DIFF
--- a/app/shell-window/ui/navbar/browser-menu.js
+++ b/app/shell-window/ui/navbar/browser-menu.js
@@ -19,7 +19,7 @@ export class BrowserMenuNavbarBtn {
       newWindow: cmdOrCtrlChar + 'N',
       newTab: cmdOrCtrlChar + 'T',
       findInPage: cmdOrCtrlChar + 'F',
-      history: cmdOrCtrlChar + 'Y',
+      history: cmdOrCtrlChar + (isDarwin ? 'Y' : 'H'),
       openFile: cmdOrCtrlChar + 'O'
     }
 


### PR DESCRIPTION
This fixes a small UI bug where keyboard shortcut lto open browsing History in dropdown menu was incorrect for Linux.

Closes #904

As always, thanks for making Beaker -- 0.8 is  looking awesome!