### PR TITLE
Support tab navigation in navbar autocomplete

### DIFF
--- a/app/npmls.txt
+++ b/app/npmls.txt
@@ -1,0 +1,966 @@
+beaker-browser@0.8.0-prerelease.3 /home/brecht/beakerbrowser/beaker/app
+├─┬ anymatch@1.3.2
+│ ├─┬ micromatch@2.3.11
+│ │ ├─┬ arr-diff@2.0.0
+│ │ │ └── arr-flatten@1.1.0
+│ │ ├── array-unique@0.2.1
+│ │ ├─┬ braces@1.8.5
+│ │ │ ├─┬ expand-range@1.8.2
+│ │ │ │ └─┬ fill-range@2.2.3
+│ │ │ │   ├─┬ is-number@2.1.0
+│ │ │ │   │ └── kind-of@3.2.2 deduped
+│ │ │ │   ├─┬ isobject@2.1.0
+│ │ │ │   │ └── isarray@1.0.0 deduped
+│ │ │ │   ├─┬ randomatic@1.1.7
+│ │ │ │   │ ├─┬ is-number@3.0.0
+│ │ │ │   │ │ └─┬ kind-of@3.2.2
+│ │ │ │   │ │   └── is-buffer@1.1.6 deduped
+│ │ │ │   │ └─┬ kind-of@4.0.0
+│ │ │ │   │   └── is-buffer@1.1.6 deduped
+│ │ │ │   ├── repeat-element@1.1.2 deduped
+│ │ │ │   └── repeat-string@1.6.1
+│ │ │ ├── preserve@0.2.0
+│ │ │ └── repeat-element@1.1.2
+│ │ ├─┬ expand-brackets@0.1.5
+│ │ │ └── is-posix-bracket@0.1.1
+│ │ ├─┬ extglob@0.3.2
+│ │ │ └── is-extglob@1.0.0 deduped
+│ │ ├── filename-regex@2.0.1
+│ │ ├── is-extglob@1.0.0
+│ │ ├─┬ is-glob@2.0.1
+│ │ │ └── is-extglob@1.0.0 deduped
+│ │ ├─┬ kind-of@3.2.2
+│ │ │ └── is-buffer@1.1.6
+│ │ ├── normalize-path@2.1.1 deduped
+│ │ ├─┬ object.omit@2.0.1
+│ │ │ ├─┬ for-own@0.1.5
+│ │ │ │ └── for-in@1.0.2
+│ │ │ └── is-extendable@0.1.1
+│ │ ├─┬ parse-glob@3.0.4
+│ │ │ ├─┬ glob-base@0.3.0
+│ │ │ │ ├─┬ glob-parent@2.0.0
+│ │ │ │ │ └── is-glob@2.0.1 deduped
+│ │ │ │ └── is-glob@2.0.1 deduped
+│ │ │ ├── is-dotfile@1.0.3
+│ │ │ ├── is-extglob@1.0.0 deduped
+│ │ │ └── is-glob@2.0.1 deduped
+│ │ └─┬ regex-cache@0.4.4
+│ │   └─┬ is-equal-shallow@0.1.3
+│ │     └── is-primitive@2.0.0
+│ └─┬ normalize-path@2.1.1
+│   └── remove-trailing-separator@1.1.0
+├── await-lock@1.1.2
+├── beaker-error-constants@1.4.0
+├─┬ beaker-profiles-api@2.4.2
+│ ├── concat-stream@1.6.2 deduped
+│ ├── ingestdb@2.4.7 deduped
+│ ├─┬ monotonic-timestamp-base36@1.0.0
+│ │ └── monotonic-timestamp@0.0.9
+│ ├── normalize-url@1.9.1 deduped
+│ ├── slugify-url@1.2.0
+│ └── through2@2.0.3 deduped
+├─┬ beaker-virtual-fs@1.0.0 (git://github.com/beakerbrowser/beaker-virtual-fs.git#d27824f0730354a87d36d9d40926607b1ec6328a)
+│ └── text-extensions@1.7.0
+├── binary-extensions@1.11.0
+├─┬ builtin-pages-lib@1.0.0 (git://github.com/beakerbrowser/builtin-pages-lib.git#e6c36086fb85d14325b4db5196f1aa1b68cf9e90)
+│ ├── co@4.6.0 deduped
+│ ├── emit-stream@0.1.2 deduped
+│ ├── speedometer@1.0.0 deduped
+│ └── yo-yo@1.4.1 deduped
+├── bytes@2.5.0
+├─┬ choo@5.6.2
+│ ├─┬ bel@4.6.0
+│ │ ├─┬ global@4.3.2
+│ │ │ ├─┬ min-document@2.19.0
+│ │ │ │ └── dom-walk@0.1.1
+│ │ │ └── process@0.5.2
+│ │ ├─┬ hyperx@2.4.0
+│ │ │ └── hyperscript-attribute-to-property@1.0.0
+│ │ └─┬ on-load@3.4.0
+│ │   ├── global@4.3.2 deduped
+│ │   └── nanoassert@1.1.0
+│ ├── document-ready@2.0.1
+│ ├─┬ nanobus@3.3.0
+│ │ └── nanotiming@1.0.1
+│ ├── nanohistory@1.0.0
+│ ├── nanohref@1.0.0
+│ ├── nanomorph@4.0.5
+│ ├─┬ nanomount@1.0.1
+│ │ └── nanomorph@4.0.5 deduped
+│ ├── nanoraf@3.0.1
+│ └─┬ nanorouter@2.2.0
+│   └─┬ wayfarer@6.6.3
+│     └── xtend@4.0.1 deduped
+├─┬ circular-append-file@1.0.1
+│ └─┬ multistream@2.1.0
+│   ├── inherits@2.0.3 deduped
+│   └── readable-stream@2.3.5 deduped
+├── co@4.6.0
+├─┬ concat-stream@1.6.2
+│ ├── buffer-from@1.0.0
+│ ├── inherits@2.0.3
+│ ├─┬ readable-stream@2.3.5
+│ │ ├── core-util-is@1.0.2
+│ │ ├── inherits@2.0.3 deduped
+│ │ ├── isarray@1.0.0
+│ │ ├── process-nextick-args@2.0.0
+│ │ ├── safe-buffer@5.1.1 deduped
+│ │ ├─┬ string_decoder@1.0.3
+│ │ │ └── safe-buffer@5.1.1 deduped
+│ │ └── util-deprecate@1.0.2
+│ └── typedarray@0.0.6
+├─┬ contains-ads@0.2.5
+│ └─┬ ad-block@2.1.0
+│   ├── bloom-filter-cpp@1.1.6
+│   ├── cppunitlite@1.0.0
+│   ├── hashset-cpp@1.0.18
+│   └── nan@2.8.0 deduped
+├─┬ dat-dns@2.0.0
+│ ├── call-me-maybe@1.0.1
+│ ├── concat-stream@1.6.2 deduped
+│ └── debug@2.6.8 deduped (git://github.com/beakerbrowser/debug.git#8d79a96e2c5f79527d7580960be3da9ae246ed8e)
+├─┬ dat-encoding@4.0.2
+│ └── safe-buffer@5.1.1
+├─┬ datland-swarm-defaults@1.0.2
+│ └── xtend@4.0.1
+├─┬ debug@2.6.8 (git://github.com/beakerbrowser/debug.git#8d79a96e2c5f79527d7580960be3da9ae246ed8e)
+│ └── ms@2.0.0
+├─┬ devtron@1.4.0
+│ ├── accessibility-developer-tools@2.12.0
+│ ├── highlight.js@9.12.0
+│ └── humanize-plus@1.8.2
+├── diff@3.5.0
+├─┬ diff-file-tree@2.1.1
+│ ├── debug@2.6.8 deduped (git://github.com/beakerbrowser/debug.git#8d79a96e2c5f79527d7580960be3da9ae246ed8e)
+│ ├─┬ es6-promisify@5.0.0
+│ │ └── es6-promise@4.2.4
+│ ├── pump@1.0.3 deduped
+│ ├─┬ stream-equal@1.1.1
+│ │ └── @types/node@9.6.0
+│ └─┬ tempy@0.1.0
+│   ├── pify@2.3.0 deduped
+│   ├── temp-dir@1.0.0
+│   └─┬ unique-string@1.0.0
+│     └── crypto-random-string@1.0.0
+├─┬ discovery-swarm@5.0.0
+│ ├── buffer-equals@1.0.4
+│ ├── connections@1.4.2
+│ ├── debug@2.6.8 deduped (git://github.com/beakerbrowser/debug.git#8d79a96e2c5f79527d7580960be3da9ae246ed8e)
+│ ├─┬ discovery-channel@5.5.1
+│ │ ├─┬ bittorrent-dht@7.10.0
+│ │ │ ├─┬ bencode@1.0.0
+│ │ │ │ └── safe-buffer@5.1.1 deduped
+│ │ │ ├── buffer-equals@1.0.4 deduped
+│ │ │ ├─┬ debug@3.1.0
+│ │ │ │ └── ms@2.0.0
+│ │ │ ├── inherits@2.0.3 deduped
+│ │ │ ├─┬ k-bucket@3.3.1
+│ │ │ │ ├── buffer-equals@1.0.4 deduped
+│ │ │ │ ├── inherits@2.0.3 deduped
+│ │ │ │ └── randombytes@2.0.6 deduped
+│ │ │ ├─┬ k-rpc@4.3.1
+│ │ │ │ ├── buffer-equals@1.0.4 deduped
+│ │ │ │ ├─┬ k-bucket@4.0.0
+│ │ │ │ │ ├── inherits@2.0.3 deduped
+│ │ │ │ │ └── randombytes@2.0.6 deduped
+│ │ │ │ ├─┬ k-rpc-socket@1.8.0
+│ │ │ │ │ ├─┬ bencode@2.0.0
+│ │ │ │ │ │ └── safe-buffer@5.1.1 deduped
+│ │ │ │ │ ├── buffer-equals@1.0.4 deduped
+│ │ │ │ │ └── safe-buffer@5.1.1 deduped
+│ │ │ │ ├── randombytes@2.0.6 deduped
+│ │ │ │ └── safe-buffer@5.1.1 deduped
+│ │ │ ├─┬ lru@3.1.0
+│ │ │ │ └── inherits@2.0.3 deduped
+│ │ │ ├─┬ randombytes@2.0.6
+│ │ │ │ └── safe-buffer@5.1.1 deduped
+│ │ │ ├── safe-buffer@5.1.1 deduped
+│ │ │ └─┬ simple-sha1@2.1.0
+│ │ │   └── rusha@0.8.13
+│ │ ├── buffer-from@1.0.0 deduped
+│ │ ├─┬ debug@2.6.9
+│ │ │ └── ms@2.0.0
+│ │ ├─┬ dns-discovery@6.1.0
+│ │ │ ├── circular-append-file@1.0.1 deduped
+│ │ │ ├─┬ debug@2.6.9
+│ │ │ │ └── ms@2.0.0
+│ │ │ ├─┬ dns-socket@3.0.0
+│ │ │ │ └─┬ dns-packet@4.1.0
+│ │ │ │   ├── ip@1.1.5
+│ │ │ │   └── safe-buffer@5.1.1 deduped
+│ │ │ ├─┬ lru@2.0.1
+│ │ │ │ └── inherits@2.0.3 deduped
+│ │ │ ├── minimist@1.2.0
+│ │ │ ├─┬ multicast-dns@7.0.0
+│ │ │ │ ├── dns-packet@4.1.0 deduped
+│ │ │ │ └── thunky@1.0.2
+│ │ │ ├── network-address@1.1.2
+│ │ │ ├─┬ pump@3.0.0
+│ │ │ │ ├── end-of-stream@1.4.1 deduped
+│ │ │ │ └── once@1.4.0 deduped
+│ │ │ ├── speedometer@1.0.0 deduped
+│ │ │ └── unordered-set@1.1.0
+│ │ ├── pretty-hash@1.0.1 deduped
+│ │ └── thunky@0.1.0
+│ ├─┬ length-prefixed-message@3.0.3
+│ │ └── varint@3.0.1
+│ ├── pump@1.0.3 deduped
+│ ├── to-buffer@1.1.0
+│ └── utp-native@1.7.0 deduped
+├─┬ dns-txt@2.0.2
+│ └── buffer-indexof@1.1.1
+├─┬ drag-drop@2.13.2
+│ ├── blob-to-buffer@1.2.7
+│ ├── flatten@1.0.2
+│ └── run-parallel@1.1.8
+├─┬ du@0.1.0 (git://github.com/beakerbrowser/node-du.git#8db9ed862712a964289d2d07e58f2d7ec543a56e)
+│ └── async@0.1.22
+├── electron-localshortcut@0.6.1
+├─┬ electron-updater@2.21.3
+│ ├─┬ bluebird-lst@1.0.5
+│ │ └── bluebird@3.5.1
+│ ├─┬ builder-util-runtime@4.2.0
+│ │ ├── bluebird-lst@1.0.5 deduped
+│ │ ├─┬ debug@3.1.0
+│ │ │ └── ms@2.0.0
+│ │ ├── fs-extra-p@4.5.2 deduped
+│ │ └── sax@1.2.4
+│ ├── electron-is-dev@0.3.0
+│ ├─┬ fs-extra-p@4.5.2
+│ │ ├── bluebird-lst@1.0.5 deduped
+│ │ └─┬ fs-extra@5.0.0
+│ │   ├── graceful-fs@4.1.11 deduped
+│ │   ├── jsonfile@4.0.0 deduped
+│ │   └── universalify@0.1.1 deduped
+│ ├─┬ js-yaml@3.11.0
+│ │ ├─┬ argparse@1.0.10
+│ │ │ └── sprintf-js@1.0.3
+│ │ └── esprima@4.0.0
+│ ├── lazy-val@1.0.3
+│ ├── lodash.isequal@4.5.0
+│ ├── semver@5.5.0
+│ └─┬ source-map-support@0.5.4
+│   └── source-map@0.6.1
+├─┬ emit-stream@0.1.2
+│ └── through@2.3.8
+├─┬ from2@2.3.0
+│ ├── inherits@2.0.3 deduped
+│ └── readable-stream@2.3.5 deduped
+├─┬ from2-encoding@1.0.0
+│ └── from2@2.3.0 deduped
+├─┬ from2-string@1.1.0
+│ └── from2@2.3.0 deduped
+├─┬ fs-jetpack@0.9.2
+│ ├─┬ minimatch@3.0.4
+│ │ └─┬ brace-expansion@1.1.11
+│ │   ├── balanced-match@1.0.0
+│ │   └── concat-map@0.0.1
+│ ├── mkdirp@0.5.1 deduped
+│ ├── q@1.5.1
+│ └─┬ rimraf@2.6.2
+│   └─┬ glob@7.1.2
+│     ├── fs.realpath@1.0.0
+│     ├─┬ inflight@1.0.6
+│     │ ├── once@1.4.0 deduped
+│     │ └── wrappy@1.0.2 deduped
+│     ├── inherits@2.0.3 deduped
+│     ├── minimatch@3.0.4 deduped
+│     ├── once@1.4.0 deduped
+│     └── path-is-absolute@1.0.1
+├── function-queue@0.0.12
+├─┬ hypercore@6.12.5
+│ ├── array-lru@1.1.1
+│ ├── atomic-batcher@1.0.2
+│ ├─┬ bitfield-rle@2.1.0
+│ │ └── varint@4.0.1
+│ ├── buffer-alloc-unsafe@1.0.0
+│ ├── buffer-equals@1.0.4 deduped
+│ ├── buffer-from@1.0.0 deduped
+│ ├─┬ bulk-write-stream@1.1.4
+│ │ ├── buffer-from@1.0.0 deduped
+│ │ ├── inherits@2.0.3 deduped
+│ │ └── readable-stream@2.3.5 deduped
+│ ├── codecs@1.2.1
+│ ├── flat-tree@1.6.0
+│ ├── from2@2.3.0 deduped
+│ ├── hypercore-protocol@6.6.2 deduped
+│ ├── inherits@2.0.3 deduped
+│ ├── last-one-wins@1.0.4
+│ ├── memory-pager@1.1.0
+│ ├─┬ merkle-tree-stream@3.0.3
+│ │ ├── flat-tree@1.6.0 deduped
+│ │ └── readable-stream@2.3.5 deduped
+│ ├── process-nextick-args@1.0.7
+│ ├─┬ random-access-file@2.0.1
+│ │ ├── mkdirp@0.5.1 deduped
+│ │ └─┬ random-access-storage@1.1.1
+│ │   └── inherits@2.0.3 deduped
+│ ├─┬ sodium-universal@2.0.0
+│ │ ├─┬ sodium-javascript@0.5.5
+│ │ │ ├─┬ blake2b@2.1.2
+│ │ │ │ ├─┬ blake2b-wasm@1.1.7
+│ │ │ │ │ └── nanoassert@1.1.0 deduped
+│ │ │ │ └── nanoassert@1.1.0 deduped
+│ │ │ ├── nanoassert@1.1.0 deduped
+│ │ │ ├─┬ siphash24@1.1.0
+│ │ │ │ └── nanoassert@1.1.0 deduped
+│ │ │ └── xsalsa20@1.0.2
+│ │ └─┬ sodium-native@2.1.4
+│ │   ├── ini@1.3.5
+│ │   ├── nan@2.8.0 deduped
+│ │   └── node-gyp-build@3.3.0 deduped
+│ ├─┬ sparse-bitfield@3.0.3
+│ │ └── memory-pager@1.1.0 deduped
+│ ├── thunky@1.0.2
+│ ├─┬ uint64be@2.0.2
+│ │ └─┬ buffer-alloc@1.1.0
+│ │   ├── buffer-alloc-unsafe@0.1.1
+│ │   └── buffer-fill@0.1.0
+│ ├── unordered-array-remove@1.0.2
+│ └── unordered-set@2.0.0
+├─┬ hypercore-protocol@6.6.2
+│ ├── buffer-alloc-unsafe@1.0.0 deduped
+│ ├── buffer-from@1.0.0 deduped
+│ ├── inherits@2.0.3 deduped
+│ ├─┬ protocol-buffers-encodings@1.1.0
+│ │ ├─┬ signed-varint@2.0.1
+│ │ │ └── varint@5.0.0
+│ │ └── varint@5.0.0
+│ ├── readable-stream@2.3.5 deduped
+│ ├── sodium-universal@2.0.0 deduped
+│ ├── sorted-indexof@1.0.0
+│ └── varint@5.0.0
+├─┬ hyperdrive@9.12.3
+│ ├─┬ append-tree@2.4.1
+│ │ ├── array-lru@1.1.1 deduped
+│ │ ├── codecs@1.2.1 deduped
+│ │ ├── from2@2.3.0 deduped
+│ │ ├── inherits@2.0.3 deduped
+│ │ ├── mutexify@1.2.0 deduped
+│ │ ├── process-nextick-args@1.0.7
+│ │ ├── protocol-buffers-encodings@1.1.0 deduped
+│ │ └── varint@5.0.0
+│ ├─┬ duplexify@3.5.4
+│ │ ├── end-of-stream@1.4.1 deduped
+│ │ ├── inherits@2.0.3 deduped
+│ │ ├── readable-stream@2.3.5 deduped
+│ │ └── stream-shift@1.0.0
+│ ├── from2@2.3.0 deduped
+│ ├── hypercore@6.12.5 deduped
+│ ├── inherits@2.0.3 deduped
+│ ├── mutexify@1.2.0
+│ ├── protocol-buffers-encodings@1.1.0 deduped
+│ ├─┬ random-access-file@2.0.1
+│ │ ├── mkdirp@0.5.1 deduped
+│ │ └── random-access-storage@1.1.1 deduped
+│ ├── sodium-universal@2.0.0 deduped
+│ ├─┬ stream-collector@1.0.1
+│ │ └── once@1.4.0 deduped
+│ ├─┬ stream-each@1.2.2
+│ │ ├── end-of-stream@1.4.1 deduped
+│ │ └── stream-shift@1.0.0 deduped
+│ ├── thunky@1.0.2
+│ ├── uint64be@2.0.2 deduped
+│ └─┬ unixify@1.0.0
+│   └── normalize-path@2.1.1 deduped
+├─┬ hyperdrive-staging-area@2.4.0
+│ ├── anymatch@1.3.2 deduped
+│ ├── diff-file-tree@2.1.1 deduped
+│ └── scoped-fs@1.1.2 deduped
+├─┬ hyperdrive-to-zip-stream@2.0.0
+│ ├── from2@2.3.0 deduped
+│ ├─┬ pauls-dat-api@4.5.0
+│ │ ├── anymatch@1.3.2 deduped
+│ │ ├── beaker-error-constants@1.4.0 deduped
+│ │ ├── call-me-maybe@1.0.1 deduped
+│ │ ├── co@4.6.0 deduped
+│ │ ├── dat-encoding@4.0.2 deduped
+│ │ ├── emit-stream@0.1.2 deduped
+│ │ ├─┬ fs-promise@2.0.3
+│ │ │ ├── any-promise@1.3.0
+│ │ │ ├─┬ fs-extra@2.1.2
+│ │ │ │ ├── graceful-fs@4.1.11 deduped
+│ │ │ │ └─┬ jsonfile@2.4.0
+│ │ │ │   └── graceful-fs@4.1.11 deduped
+│ │ │ ├─┬ mz@2.7.0
+│ │ │ │ ├── any-promise@1.3.0 deduped
+│ │ │ │ ├── object-assign@4.1.1 deduped
+│ │ │ │ └── thenify-all@1.6.0 deduped
+│ │ │ └─┬ thenify-all@1.6.0
+│ │ │   └─┬ thenify@3.3.0
+│ │ │     └── any-promise@1.3.0 deduped
+│ │ ├─┬ hyperdrive-import-files@3.0.0
+│ │ │ ├── anymatch@1.3.2 deduped
+│ │ │ ├─┬ chokidar@1.7.0
+│ │ │ │ ├── anymatch@1.3.2 deduped
+│ │ │ │ ├── async-each@1.0.1
+│ │ │ │ ├─┬ UNMET OPTIONAL DEPENDENCY fsevents@1.1.3
+│ │ │ │ │ ├── nan@2.8.0 deduped
+│ │ │ │ │ └─┬ UNMET OPTIONAL DEPENDENCY node-pre-gyp@0.6.39
+│ │ │ │ │   ├── UNMET OPTIONAL DEPENDENCY detect-libc@1.0.2
+│ │ │ │ │   ├─┬ UNMET DEPENDENCY hawk@3.1.3
+│ │ │ │ │   │ ├─┬ UNMET DEPENDENCY boom@2.10.1
+│ │ │ │ │   │ │ └── UNMET DEPENDENCY hoek@2.16.3
+│ │ │ │ │   │ ├─┬ UNMET DEPENDENCY cryptiles@2.0.5
+│ │ │ │ │   │ │ └── UNMET DEPENDENCY boom@2.10.1
+│ │ │ │ │   │ ├── UNMET DEPENDENCY hoek@2.16.3
+│ │ │ │ │   │ └─┬ UNMET DEPENDENCY sntp@1.0.9
+│ │ │ │ │   │   └── UNMET DEPENDENCY hoek@2.16.3
+│ │ │ │ │   ├─┬ UNMET DEPENDENCY mkdirp@0.5.1
+│ │ │ │ │   │ └── UNMET DEPENDENCY minimist@0.0.8
+│ │ │ │ │   ├─┬ UNMET OPTIONAL DEPENDENCY nopt@4.0.1
+│ │ │ │ │   │ ├── UNMET OPTIONAL DEPENDENCY abbrev@1.1.0
+│ │ │ │ │   │ └─┬ UNMET OPTIONAL DEPENDENCY osenv@0.1.4
+│ │ │ │ │   │   ├── UNMET OPTIONAL DEPENDENCY os-homedir@1.0.2
+│ │ │ │ │   │   └── UNMET OPTIONAL DEPENDENCY os-tmpdir@1.0.2
+│ │ │ │ │   ├─┬ UNMET OPTIONAL DEPENDENCY npmlog@4.1.0
+│ │ │ │ │   │ ├─┬ UNMET OPTIONAL DEPENDENCY are-we-there-yet@1.1.4
+│ │ │ │ │   │ │ ├── UNMET OPTIONAL DEPENDENCY delegates@1.0.0
+│ │ │ │ │   │ │ └── UNMET DEPENDENCY readable-stream@2.2.9
+│ │ │ │ │   │ ├── UNMET DEPENDENCY console-control-strings@1.1.0
+│ │ │ │ │   │ ├─┬ UNMET OPTIONAL DEPENDENCY gauge@2.7.4
+│ │ │ │ │   │ │ ├── UNMET OPTIONAL DEPENDENCY aproba@1.1.1
+│ │ │ │ │   │ │ ├── UNMET DEPENDENCY console-control-strings@1.1.0
+│ │ │ │ │   │ │ ├── UNMET OPTIONAL DEPENDENCY has-unicode@2.0.1
+│ │ │ │ │   │ │ ├── UNMET OPTIONAL DEPENDENCY object-assign@4.1.1
+│ │ │ │ │   │ │ ├── UNMET OPTIONAL DEPENDENCY signal-exit@3.0.2
+│ │ │ │ │   │ │ ├─┬ UNMET DEPENDENCY string-width@1.0.2
+│ │ │ │ │   │ │ │ ├── UNMET DEPENDENCY code-point-at@1.1.0
+│ │ │ │ │   │ │ │ ├─┬ UNMET DEPENDENCY is-fullwidth-code-point@1.0.0
+│ │ │ │ │   │ │ │ │ └── UNMET DEPENDENCY number-is-nan@1.0.1
+│ │ │ │ │   │ │ │ └── UNMET DEPENDENCY strip-ansi@3.0.1
+│ │ │ │ │   │ │ ├─┬ UNMET DEPENDENCY strip-ansi@3.0.1
+│ │ │ │ │   │ │ │ └── UNMET DEPENDENCY ansi-regex@2.1.1
+│ │ │ │ │   │ │ └─┬ UNMET OPTIONAL DEPENDENCY wide-align@1.1.2
+│ │ │ │ │   │ │   └── UNMET DEPENDENCY string-width@1.0.2
+│ │ │ │ │   │ └── UNMET OPTIONAL DEPENDENCY set-blocking@2.0.0
+│ │ │ │ │   ├─┬ UNMET OPTIONAL DEPENDENCY rc@1.2.1
+│ │ │ │ │   │ ├── UNMET OPTIONAL DEPENDENCY deep-extend@0.4.2
+│ │ │ │ │   │ ├── UNMET OPTIONAL DEPENDENCY ini@1.3.4
+│ │ │ │ │   │ ├── UNMET OPTIONAL DEPENDENCY minimist@1.2.0
+│ │ │ │ │   │ └── UNMET OPTIONAL DEPENDENCY strip-json-comments@2.0.1
+│ │ │ │ │   ├─┬ UNMET OPTIONAL DEPENDENCY request@2.81.0
+│ │ │ │ │   │ ├── UNMET OPTIONAL DEPENDENCY aws-sign2@0.6.0
+│ │ │ │ │   │ ├── UNMET OPTIONAL DEPENDENCY aws4@1.6.0
+│ │ │ │ │   │ ├── UNMET OPTIONAL DEPENDENCY caseless@0.12.0
+│ │ │ │ │   │ ├─┬ UNMET DEPENDENCY combined-stream@1.0.5
+│ │ │ │ │   │ │ └── UNMET DEPENDENCY delayed-stream@1.0.0
+│ │ │ │ │   │ ├── UNMET OPTIONAL DEPENDENCY extend@3.0.1
+│ │ │ │ │   │ ├── UNMET OPTIONAL DEPENDENCY forever-agent@0.6.1
+│ │ │ │ │   │ ├─┬ UNMET OPTIONAL DEPENDENCY form-data@2.1.4
+│ │ │ │ │   │ │ ├── UNMET OPTIONAL DEPENDENCY asynckit@0.4.0
+│ │ │ │ │   │ │ ├── UNMET DEPENDENCY combined-stream@1.0.5
+│ │ │ │ │   │ │ └── UNMET DEPENDENCY mime-types@2.1.15
+│ │ │ │ │   │ ├─┬ UNMET OPTIONAL DEPENDENCY har-validator@4.2.1
+│ │ │ │ │   │ │ ├─┬ UNMET OPTIONAL DEPENDENCY ajv@4.11.8
+│ │ │ │ │   │ │ │ ├── UNMET OPTIONAL DEPENDENCY co@4.6.0
+│ │ │ │ │   │ │ │ └─┬ UNMET OPTIONAL DEPENDENCY json-stable-stringify@1.0.1
+│ │ │ │ │   │ │ │   └── UNMET OPTIONAL DEPENDENCY jsonify@0.0.0
+│ │ │ │ │   │ │ └── UNMET OPTIONAL DEPENDENCY har-schema@1.0.5
+│ │ │ │ │   │ ├── UNMET DEPENDENCY hawk@3.1.3
+│ │ │ │ │   │ ├─┬ UNMET OPTIONAL DEPENDENCY http-signature@1.1.1
+│ │ │ │ │   │ │ ├── UNMET OPTIONAL DEPENDENCY assert-plus@0.2.0
+│ │ │ │ │   │ │ ├─┬ UNMET OPTIONAL DEPENDENCY jsprim@1.4.0
+│ │ │ │ │   │ │ │ ├── UNMET OPTIONAL DEPENDENCY assert-plus@1.0.0
+│ │ │ │ │   │ │ │ ├── UNMET DEPENDENCY extsprintf@1.0.2
+│ │ │ │ │   │ │ │ ├── UNMET OPTIONAL DEPENDENCY json-schema@0.2.3
+│ │ │ │ │   │ │ │ └─┬ UNMET OPTIONAL DEPENDENCY verror@1.3.6
+│ │ │ │ │   │ │ │   └── UNMET DEPENDENCY extsprintf@1.0.2
+│ │ │ │ │   │ │ └─┬ UNMET OPTIONAL DEPENDENCY sshpk@1.13.0
+│ │ │ │ │   │ │   ├── UNMET OPTIONAL DEPENDENCY asn1@0.2.3
+│ │ │ │ │   │ │   ├── UNMET OPTIONAL DEPENDENCY assert-plus@1.0.0
+│ │ │ │ │   │ │   ├─┬ UNMET OPTIONAL DEPENDENCY bcrypt-pbkdf@1.0.1
+│ │ │ │ │   │ │   │ └── UNMET OPTIONAL DEPENDENCY tweetnacl@0.14.5
+│ │ │ │ │   │ │   ├─┬ UNMET OPTIONAL DEPENDENCY dashdash@1.14.1
+│ │ │ │ │   │ │   │ └── UNMET OPTIONAL DEPENDENCY assert-plus@1.0.0
+│ │ │ │ │   │ │   ├─┬ UNMET OPTIONAL DEPENDENCY ecc-jsbn@0.1.1
+│ │ │ │ │   │ │   │ └── UNMET OPTIONAL DEPENDENCY jsbn@0.1.1
+│ │ │ │ │   │ │   ├─┬ UNMET OPTIONAL DEPENDENCY getpass@0.1.7
+│ │ │ │ │   │ │   │ └── UNMET OPTIONAL DEPENDENCY assert-plus@1.0.0
+│ │ │ │ │   │ │   ├─┬ UNMET OPTIONAL DEPENDENCY jodid25519@1.0.2
+│ │ │ │ │   │ │   │ └── UNMET OPTIONAL DEPENDENCY jsbn@0.1.1
+│ │ │ │ │   │ │   ├── UNMET OPTIONAL DEPENDENCY jsbn@0.1.1
+│ │ │ │ │   │ │   └── UNMET OPTIONAL DEPENDENCY tweetnacl@0.14.5
+│ │ │ │ │   │ ├── UNMET OPTIONAL DEPENDENCY is-typedarray@1.0.0
+│ │ │ │ │   │ ├── UNMET OPTIONAL DEPENDENCY isstream@0.1.2
+│ │ │ │ │   │ ├── UNMET OPTIONAL DEPENDENCY json-stringify-safe@5.0.1
+│ │ │ │ │   │ ├─┬ UNMET DEPENDENCY mime-types@2.1.15
+│ │ │ │ │   │ │ └── UNMET DEPENDENCY mime-db@1.27.0
+│ │ │ │ │   │ ├── UNMET OPTIONAL DEPENDENCY oauth-sign@0.8.2
+│ │ │ │ │   │ ├── UNMET OPTIONAL DEPENDENCY performance-now@0.2.0
+│ │ │ │ │   │ ├── UNMET OPTIONAL DEPENDENCY qs@6.4.0
+│ │ │ │ │   │ ├── UNMET DEPENDENCY safe-buffer@5.0.1
+│ │ │ │ │   │ ├── UNMET OPTIONAL DEPENDENCY stringstream@0.0.5
+│ │ │ │ │   │ ├─┬ UNMET OPTIONAL DEPENDENCY tough-cookie@2.3.2
+│ │ │ │ │   │ │ └── UNMET OPTIONAL DEPENDENCY punycode@1.4.1
+│ │ │ │ │   │ ├─┬ UNMET OPTIONAL DEPENDENCY tunnel-agent@0.6.0
+│ │ │ │ │   │ │ └── UNMET DEPENDENCY safe-buffer@5.0.1
+│ │ │ │ │   │ └── UNMET OPTIONAL DEPENDENCY uuid@3.0.1
+│ │ │ │ │   ├─┬ UNMET DEPENDENCY rimraf@2.6.1
+│ │ │ │ │   │ └─┬ UNMET DEPENDENCY glob@7.1.2
+│ │ │ │ │   │   ├── UNMET DEPENDENCY fs.realpath@1.0.0
+│ │ │ │ │   │   ├─┬ UNMET DEPENDENCY inflight@1.0.6
+│ │ │ │ │   │   │ ├── UNMET DEPENDENCY once@1.4.0
+│ │ │ │ │   │   │ └── UNMET DEPENDENCY wrappy@1.0.2
+│ │ │ │ │   │   ├── UNMET DEPENDENCY inherits@2.0.3
+│ │ │ │ │   │   ├─┬ UNMET DEPENDENCY minimatch@3.0.4
+│ │ │ │ │   │   │ └─┬ UNMET DEPENDENCY brace-expansion@1.1.7
+│ │ │ │ │   │   │   ├── UNMET DEPENDENCY balanced-match@0.4.2
+│ │ │ │ │   │   │   └── UNMET DEPENDENCY concat-map@0.0.1
+│ │ │ │ │   │   ├── UNMET DEPENDENCY once@1.4.0
+│ │ │ │ │   │   └── UNMET DEPENDENCY path-is-absolute@1.0.1
+│ │ │ │ │   ├── UNMET OPTIONAL DEPENDENCY semver@5.3.0
+│ │ │ │ │   ├─┬ UNMET DEPENDENCY tar@2.2.1
+│ │ │ │ │   │ ├─┬ UNMET DEPENDENCY block-stream@0.0.9
+│ │ │ │ │   │ │ └── UNMET DEPENDENCY inherits@2.0.3
+│ │ │ │ │   │ ├─┬ UNMET DEPENDENCY fstream@1.0.11
+│ │ │ │ │   │ │ ├── UNMET DEPENDENCY graceful-fs@4.1.11
+│ │ │ │ │   │ │ ├── UNMET DEPENDENCY inherits@2.0.3
+│ │ │ │ │   │ │ ├── UNMET DEPENDENCY mkdirp@0.5.1
+│ │ │ │ │   │ │ └── UNMET DEPENDENCY rimraf@2.6.1
+│ │ │ │ │   │ └── UNMET DEPENDENCY inherits@2.0.3
+│ │ │ │ │   └─┬ UNMET OPTIONAL DEPENDENCY tar-pack@3.4.0
+│ │ │ │ │     ├─┬ UNMET OPTIONAL DEPENDENCY debug@2.6.8
+│ │ │ │ │     │ └── UNMET OPTIONAL DEPENDENCY ms@2.0.0
+│ │ │ │ │     ├── UNMET DEPENDENCY fstream@1.0.11
+│ │ │ │ │     ├─┬ UNMET OPTIONAL DEPENDENCY fstream-ignore@1.0.5
+│ │ │ │ │     │ ├── UNMET DEPENDENCY fstream@1.0.11
+│ │ │ │ │     │ ├── UNMET DEPENDENCY inherits@2.0.3
+│ │ │ │ │     │ └── UNMET DEPENDENCY minimatch@3.0.4
+│ │ │ │ │     ├─┬ UNMET DEPENDENCY once@1.4.0
+│ │ │ │ │     │ └── UNMET DEPENDENCY wrappy@1.0.2
+│ │ │ │ │     ├─┬ UNMET DEPENDENCY readable-stream@2.2.9
+│ │ │ │ │     │ ├── UNMET DEPENDENCY buffer-shims@1.0.0
+│ │ │ │ │     │ ├── UNMET DEPENDENCY core-util-is@1.0.2
+│ │ │ │ │     │ ├── UNMET DEPENDENCY inherits@2.0.3
+│ │ │ │ │     │ ├── UNMET DEPENDENCY isarray@1.0.0
+│ │ │ │ │     │ ├── UNMET DEPENDENCY process-nextick-args@1.0.7
+│ │ │ │ │     │ ├─┬ UNMET DEPENDENCY string_decoder@1.0.1
+│ │ │ │ │     │ │ └── UNMET DEPENDENCY safe-buffer@5.0.1
+│ │ │ │ │     │ └── UNMET DEPENDENCY util-deprecate@1.0.2
+│ │ │ │ │     ├── UNMET DEPENDENCY rimraf@2.6.1
+│ │ │ │ │     ├── UNMET DEPENDENCY tar@2.2.1
+│ │ │ │ │     └── UNMET OPTIONAL DEPENDENCY uid-number@0.0.6
+│ │ │ │ ├── glob-parent@2.0.0 deduped
+│ │ │ │ ├── inherits@2.0.3 deduped
+│ │ │ │ ├─┬ is-binary-path@1.0.1
+│ │ │ │ │ └── binary-extensions@1.11.0 deduped
+│ │ │ │ ├── is-glob@2.0.1 deduped
+│ │ │ │ ├── path-is-absolute@1.0.1 deduped
+│ │ │ │ └─┬ readdirp@2.1.0
+│ │ │ │   ├── graceful-fs@4.1.11 deduped
+│ │ │ │   ├── minimatch@3.0.4 deduped
+│ │ │ │   ├── readable-stream@2.3.5 deduped
+│ │ │ │   └── set-immediate-shim@1.0.1
+│ │ │ ├── UNMET PEER DEPENDENCY hyperdrive@^8.0.0
+│ │ │ ├─┬ hyperdrive-duplicate@2.0.0
+│ │ │ │ └─┬ stream-equal@0.1.13
+│ │ │ │   └── @types/node@9.6.0 deduped
+│ │ │ ├── pump@1.0.3 deduped
+│ │ │ ├── run-series@1.1.6
+│ │ │ └── through2@2.0.3 deduped
+│ │ └── pump@1.0.3 deduped
+│ ├─┬ through2-concurrent@1.1.1
+│ │ └── through2@2.0.3 deduped
+│ └─┬ yazl@2.4.3
+│   └── buffer-crc32@0.2.13
+├─┬ icojs@0.11.0
+│ ├── bmp-js@0.0.3
+│ ├─┬ decode-ico@0.2.1
+│ │ └── to-data-view@1.0.0 deduped
+│ ├── file-type@7.6.0
+│ ├── jpeg-js@0.3.3
+│ ├── pngjs@3.3.2
+│ ├── safe-buffer@5.1.1 deduped
+│ └── to-data-view@1.0.0
+├── identify-filetype@1.0.0
+├─┬ ingestdb@2.4.7
+│ ├── anymatch@1.3.2 deduped
+│ ├── await-lock@1.1.2 deduped
+│ ├─┬ ingestdb-level@1.0.5
+│ │ ├── await-lock@1.1.2 deduped
+│ │ ├── level-promise@2.1.1 deduped
+│ │ ├─┬ readable-stream@2.2.11
+│ │ │ ├── core-util-is@1.0.2 deduped
+│ │ │ ├── inherits@2.0.3 deduped
+│ │ │ ├── isarray@1.0.0 deduped
+│ │ │ ├── process-nextick-args@1.0.7
+│ │ │ ├── safe-buffer@5.0.1
+│ │ │ ├── string_decoder@1.0.3 deduped
+│ │ │ └── util-deprecate@1.0.2 deduped
+│ │ └── xtend@4.0.1 deduped
+│ ├─┬ level-browserify@1.1.2
+│ │ ├─┬ level-js@2.2.4
+│ │ │ ├─┬ abstract-leveldown@0.12.4
+│ │ │ │ └── xtend@3.0.0
+│ │ │ ├── idb-wrapper@1.7.2
+│ │ │ ├── isbuffer@0.0.0
+│ │ │ ├── ltgt@2.2.0
+│ │ │ ├── typedarray-to-buffer@1.0.4
+│ │ │ └─┬ xtend@2.1.2
+│ │ │   └── object-keys@0.4.0
+│ │ ├─┬ level-packager@1.2.1
+│ │ │ └─┬ levelup@1.3.9
+│ │ │   ├─┬ deferred-leveldown@1.2.2
+│ │ │   │ └─┬ abstract-leveldown@2.6.3
+│ │ │   │   └── xtend@4.0.1 deduped
+│ │ │   ├── level-codec@7.0.1
+│ │ │   ├─┬ level-errors@1.0.5
+│ │ │   │ └── errno@0.1.7 deduped
+│ │ │   ├─┬ level-iterator-stream@1.3.1
+│ │ │   │ ├── inherits@2.0.3 deduped
+│ │ │   │ ├── level-errors@1.0.5 deduped
+│ │ │   │ ├─┬ readable-stream@1.1.14
+│ │ │   │ │ ├── core-util-is@1.0.2 deduped
+│ │ │   │ │ ├── inherits@2.0.3 deduped
+│ │ │   │ │ ├── isarray@0.0.1
+│ │ │   │ │ └── string_decoder@0.10.31
+│ │ │   │ └── xtend@4.0.1 deduped
+│ │ │   ├── prr@1.0.1
+│ │ │   ├── semver@5.4.1
+│ │ │   └── xtend@4.0.1 deduped
+│ │ └─┬ leveldown@3.0.0
+│ │   ├─┬ abstract-leveldown@4.0.3
+│ │   │ └── xtend@4.0.1 deduped
+│ │   ├── bindings@1.3.0
+│ │   ├── fast-future@1.0.2
+│ │   ├── nan@2.8.0 deduped
+│ │   └─┬ prebuild-install@2.5.1
+│ │     ├── detect-libc@1.0.3
+│ │     ├── expand-template@1.1.0
+│ │     ├── github-from-package@0.0.0
+│ │     ├── minimist@1.2.0 deduped
+│ │     ├── mkdirp@0.5.1 deduped
+│ │     ├─┬ node-abi@2.3.0
+│ │     │ └── semver@5.4.1 deduped
+│ │     ├── noop-logger@0.1.1
+│ │     ├─┬ npmlog@4.1.2
+│ │     │ ├─┬ are-we-there-yet@1.1.4
+│ │     │ │ ├── delegates@1.0.0
+│ │     │ │ └── readable-stream@2.3.5 deduped
+│ │     │ ├── console-control-strings@1.1.0
+│ │     │ ├─┬ gauge@2.7.4
+│ │     │ │ ├── aproba@1.2.0
+│ │     │ │ ├── console-control-strings@1.1.0 deduped
+│ │     │ │ ├── has-unicode@2.0.1
+│ │     │ │ ├── object-assign@4.1.1 deduped
+│ │     │ │ ├── signal-exit@3.0.2
+│ │     │ │ ├─┬ string-width@1.0.2
+│ │     │ │ │ ├── code-point-at@1.1.0
+│ │     │ │ │ ├─┬ is-fullwidth-code-point@1.0.0
+│ │     │ │ │ │ └── number-is-nan@1.0.1 deduped
+│ │     │ │ │ └── strip-ansi@3.0.1 deduped
+│ │     │ │ ├─┬ strip-ansi@3.0.1
+│ │     │ │ │ └── ansi-regex@2.1.1
+│ │     │ │ └─┬ wide-align@1.1.2
+│ │     │ │   └── string-width@1.0.2 deduped
+│ │     │ └── set-blocking@2.0.0
+│ │     ├── os-homedir@1.0.2
+│ │     ├─┬ pump@2.0.1
+│ │     │ ├── end-of-stream@1.4.1 deduped
+│ │     │ └── once@1.4.0 deduped
+│ │     ├─┬ rc@1.2.6
+│ │     │ ├── deep-extend@0.4.2
+│ │     │ ├── ini@1.3.5 deduped
+│ │     │ ├── minimist@1.2.0 deduped
+│ │     │ └── strip-json-comments@2.0.1
+│ │     ├─┬ simple-get@2.7.0
+│ │     │ ├─┬ decompress-response@3.3.0
+│ │     │ │ └── mimic-response@1.0.0
+│ │     │ ├── once@1.4.0 deduped
+│ │     │ └── simple-concat@1.0.0
+│ │     ├─┬ tar-fs@1.16.0
+│ │     │ ├── chownr@1.0.1
+│ │     │ ├── mkdirp@0.5.1 deduped
+│ │     │ ├── pump@1.0.3 deduped
+│ │     │ └─┬ tar-stream@1.5.5
+│ │     │   ├─┬ bl@1.2.2
+│ │     │   │ ├── readable-stream@2.3.5 deduped
+│ │     │   │ └── safe-buffer@5.1.1 deduped
+│ │     │   ├── end-of-stream@1.4.1 deduped
+│ │     │   ├── readable-stream@2.3.5 deduped
+│ │     │   └── xtend@4.0.1 deduped
+│ │     ├─┬ tunnel-agent@0.6.0
+│ │     │ └── safe-buffer@5.1.1 deduped
+│ │     └── which-pm-runs@1.0.0
+│ ├─┬ level-promise@2.1.1
+│ │ ├─┬ level-manifest@1.2.0
+│ │ │ └── deep-extend@0.2.11
+│ │ └─┬ promise@7.3.1
+│ │   └── asap@2.0.6
+│ ├─┬ level-sublevel@6.6.1
+│ │ ├─┬ bytewise@1.1.0
+│ │ │ ├─┬ bytewise-core@1.2.3
+│ │ │ │ └── typewise-core@1.2.0
+│ │ │ └─┬ typewise@1.0.3
+│ │ │   └── typewise-core@1.2.0 deduped
+│ │ ├─┬ levelup@0.19.1
+│ │ │ ├─┬ bl@0.8.2
+│ │ │ │ └── readable-stream@1.0.34 deduped
+│ │ │ ├─┬ deferred-leveldown@0.2.0
+│ │ │ │ └── abstract-leveldown@0.12.4 deduped
+│ │ │ ├─┬ errno@0.1.7
+│ │ │ │ └── prr@1.0.1 deduped
+│ │ │ ├── prr@0.0.0
+│ │ │ ├─┬ readable-stream@1.0.34
+│ │ │ │ ├── core-util-is@1.0.2 deduped
+│ │ │ │ ├── inherits@2.0.3 deduped
+│ │ │ │ ├── isarray@0.0.1
+│ │ │ │ └── string_decoder@0.10.31
+│ │ │ ├── semver@5.1.1
+│ │ │ └── xtend@3.0.0
+│ │ ├── ltgt@2.1.3
+│ │ ├─┬ pull-level@2.0.4
+│ │ │ ├─┬ level-post@1.0.7
+│ │ │ │ └── ltgt@2.2.0 deduped
+│ │ │ ├── pull-cat@1.1.11
+│ │ │ ├─┬ pull-live@1.0.1
+│ │ │ │ ├── pull-cat@1.1.11 deduped
+│ │ │ │ └── pull-stream@3.6.2 deduped
+│ │ │ ├── pull-pushable@2.2.0
+│ │ │ ├── pull-stream@3.6.2 deduped
+│ │ │ ├─┬ pull-window@2.1.4
+│ │ │ │ └── looper@2.0.0
+│ │ │ └─┬ stream-to-pull-stream@1.7.2
+│ │ │   ├── looper@3.0.0
+│ │ │   └── pull-stream@3.6.2 deduped
+│ │ ├── pull-stream@3.6.2
+│ │ ├── typewiselite@1.0.0
+│ │ └── xtend@4.0.1 deduped
+│ ├── lodash.flatten@4.4.0
+│ ├── tempy@0.1.0 deduped
+│ ├── through2@2.0.3 deduped
+│ └─┬ url-parse@1.2.0
+│   ├── querystringify@1.0.0
+│   └── requires-port@1.0.0
+├─┬ into-stream@3.1.0
+│ ├── from2@2.3.0 deduped
+│ └── p-is-promise@1.1.0
+├── listen-random-port@1.0.0
+├── lodash.flattendeep@4.4.0
+├── lodash.get@4.4.2
+├── lodash.groupby@4.6.0
+├── lodash.pick@4.4.0
+├── mime@1.6.0
+├─┬ mkdirp@0.5.1
+│ └── minimist@0.0.8
+├── moment@2.21.0
+├── ms@2.1.1
+├── multicb@1.2.2
+├─┬ normalize-url@1.9.1
+│ ├── object-assign@4.1.1
+│ ├── prepend-http@1.0.4
+│ ├─┬ query-string@4.3.4
+│ │ ├── object-assign@4.1.1 deduped
+│ │ └── strict-uri-encode@1.1.0
+│ └─┬ sort-keys@1.1.2
+│   └── is-plain-obj@1.1.0
+├─┬ once@1.4.0
+│ └── wrappy@1.0.2
+├── parse-dat-url@3.0.1
+├─┬ pauls-dat-api@6.0.0
+│ ├── anymatch@1.3.2 deduped
+│ ├── beaker-error-constants@1.4.0 deduped
+│ ├── call-me-maybe@1.0.1 deduped
+│ ├── dat-encoding@4.0.2 deduped
+│ ├── emit-stream@0.1.2 deduped
+│ ├─┬ fs-extra@4.0.3
+│ │ ├── graceful-fs@4.1.11
+│ │ ├─┬ jsonfile@4.0.0
+│ │ │ └── graceful-fs@4.1.11 deduped
+│ │ └── universalify@0.1.1
+│ └── pump@1.0.3 deduped
+├─┬ pauls-electron-rpc@4.1.2
+│ └── duplexer@0.1.1
+├── pify@2.3.0
+├─┬ pretty-bytes@3.0.1
+│ └── number-is-nan@1.0.1
+├── pretty-hash@1.0.1
+├─┬ pump@1.0.3
+│ ├─┬ end-of-stream@1.4.1
+│ │ └── once@1.4.0 deduped
+│ └── once@1.4.0 deduped
+├─┬ random-access-file@1.8.1
+│ ├── buffer-alloc-unsafe@1.0.0 deduped
+│ ├── debug@2.6.8 deduped (git://github.com/beakerbrowser/debug.git#8d79a96e2c5f79527d7580960be3da9ae246ed8e)
+│ ├── inherits@2.0.3 deduped
+│ ├── mkdirp@0.5.1 deduped
+│ └── thunky@1.0.2
+├── range-parser@1.2.0
+├─┬ remarkable@1.7.1
+│ ├─┬ argparse@0.1.16
+│ │ ├── underscore@1.7.0
+│ │ └── underscore.string@2.4.0
+│ └── autolinker@0.15.3
+├─┬ scoped-fs@1.1.2
+│ └─┬ recursive-watch@1.1.3
+│   └── ttl@1.3.1
+├── slugify@1.2.9
+├─┬ sodium-signatures@2.1.1
+│ ├── buffer-alloc-unsafe@1.0.0 deduped
+│ └── sodium-universal@2.0.0 deduped
+├── speedometer@1.0.0
+├─┬ split2@2.2.0
+│ └── through2@2.0.3 deduped
+├─┬ sqlite3@3.1.13
+│ ├── nan@2.7.0
+│ └─┬ node-pre-gyp@0.6.38
+│   ├─┬ hawk@3.1.3
+│   │ ├─┬ boom@2.10.1
+│   │ │ └── hoek@2.16.3 deduped
+│   │ ├─┬ cryptiles@2.0.5
+│   │ │ └── boom@2.10.1 deduped
+│   │ ├── hoek@2.16.3
+│   │ └─┬ sntp@1.0.9
+│   │   └── hoek@2.16.3 deduped
+│   ├─┬ mkdirp@0.5.1
+│   │ └── minimist@0.0.8
+│   ├─┬ nopt@4.0.1
+│   │ ├── abbrev@1.1.1
+│   │ └─┬ osenv@0.1.4
+│   │   ├── os-homedir@1.0.2
+│   │   └── os-tmpdir@1.0.2
+│   ├─┬ npmlog@4.1.2
+│   │ ├─┬ are-we-there-yet@1.1.4
+│   │ │ ├── delegates@1.0.0
+│   │ │ └── readable-stream@2.3.3 deduped
+│   │ ├── console-control-strings@1.1.0
+│   │ ├─┬ gauge@2.7.4
+│   │ │ ├── aproba@1.2.0
+│   │ │ ├── console-control-strings@1.1.0 deduped
+│   │ │ ├── has-unicode@2.0.1
+│   │ │ ├── object-assign@4.1.1
+│   │ │ ├── signal-exit@3.0.2
+│   │ │ ├─┬ string-width@1.0.2
+│   │ │ │ ├── code-point-at@1.1.0
+│   │ │ │ ├─┬ is-fullwidth-code-point@1.0.0
+│   │ │ │ │ └── number-is-nan@1.0.1
+│   │ │ │ └── strip-ansi@3.0.1 deduped
+│   │ │ ├─┬ strip-ansi@3.0.1
+│   │ │ │ └── ansi-regex@2.1.1
+│   │ │ └─┬ wide-align@1.1.2
+│   │ │   └── string-width@1.0.2 deduped
+│   │ └── set-blocking@2.0.0
+│   ├─┬ rc@1.2.1
+│   │ ├── deep-extend@0.4.2
+│   │ ├── ini@1.3.4
+│   │ ├── minimist@1.2.0
+│   │ └── strip-json-comments@2.0.1
+│   ├─┬ request@2.81.0
+│   │ ├── aws-sign2@0.6.0
+│   │ ├── aws4@1.6.0
+│   │ ├── caseless@0.12.0
+│   │ ├─┬ combined-stream@1.0.5
+│   │ │ └── delayed-stream@1.0.0
+│   │ ├── extend@3.0.1
+│   │ ├── forever-agent@0.6.1
+│   │ ├─┬ form-data@2.1.4
+│   │ │ ├── asynckit@0.4.0
+│   │ │ ├── combined-stream@1.0.5 deduped
+│   │ │ └── mime-types@2.1.17 deduped
+│   │ ├─┬ har-validator@4.2.1
+│   │ │ ├─┬ ajv@4.11.8
+│   │ │ │ ├── co@4.6.0
+│   │ │ │ └─┬ json-stable-stringify@1.0.1
+│   │ │ │   └── jsonify@0.0.0
+│   │ │ └── har-schema@1.0.5
+│   │ ├── hawk@3.1.3 deduped
+│   │ ├─┬ http-signature@1.1.1
+│   │ │ ├── assert-plus@0.2.0
+│   │ │ ├─┬ jsprim@1.4.1
+│   │ │ │ ├── assert-plus@1.0.0
+│   │ │ │ ├── extsprintf@1.3.0
+│   │ │ │ ├── json-schema@0.2.3
+│   │ │ │ └─┬ verror@1.10.0
+│   │ │ │   ├── assert-plus@1.0.0
+│   │ │ │   ├── core-util-is@1.0.2 deduped
+│   │ │ │   └── extsprintf@1.3.0 deduped
+│   │ │ └─┬ sshpk@1.13.1
+│   │ │   ├── asn1@0.2.3
+│   │ │   ├── assert-plus@1.0.0
+│   │ │   ├─┬ bcrypt-pbkdf@1.0.1
+│   │ │   │ └── tweetnacl@0.14.5 deduped
+│   │ │   ├─┬ dashdash@1.14.1
+│   │ │   │ └── assert-plus@1.0.0
+│   │ │   ├─┬ ecc-jsbn@0.1.1
+│   │ │   │ └── jsbn@0.1.1 deduped
+│   │ │   ├─┬ getpass@0.1.7
+│   │ │   │ └── assert-plus@1.0.0
+│   │ │   ├── jsbn@0.1.1
+│   │ │   └── tweetnacl@0.14.5
+│   │ ├── is-typedarray@1.0.0
+│   │ ├── isstream@0.1.2
+│   │ ├── json-stringify-safe@5.0.1
+│   │ ├─┬ mime-types@2.1.17
+│   │ │ └── mime-db@1.30.0
+│   │ ├── oauth-sign@0.8.2
+│   │ ├── performance-now@0.2.0
+│   │ ├── qs@6.4.0
+│   │ ├── safe-buffer@5.1.1
+│   │ ├── stringstream@0.0.5
+│   │ ├─┬ tough-cookie@2.3.3
+│   │ │ └── punycode@1.4.1
+│   │ ├─┬ tunnel-agent@0.6.0
+│   │ │ └── safe-buffer@5.1.1 deduped
+│   │ └── uuid@3.1.0
+│   ├─┬ rimraf@2.6.2
+│   │ └─┬ glob@7.1.2
+│   │   ├── fs.realpath@1.0.0
+│   │   ├─┬ inflight@1.0.6
+│   │   │ ├── once@1.4.0 deduped
+│   │   │ └── wrappy@1.0.2 deduped
+│   │   ├── inherits@2.0.3 deduped
+│   │   ├─┬ minimatch@3.0.4
+│   │   │ └─┬ brace-expansion@1.1.8
+│   │   │   ├── balanced-match@1.0.0
+│   │   │   └── concat-map@0.0.1
+│   │   ├── once@1.4.0 deduped
+│   │   └── path-is-absolute@1.0.1
+│   ├── semver@5.4.1
+│   ├─┬ tar@2.2.1
+│   │ ├─┬ block-stream@0.0.9
+│   │ │ └── inherits@2.0.3 deduped
+│   │ ├─┬ fstream@1.0.11
+│   │ │ ├── graceful-fs@4.1.11
+│   │ │ ├── inherits@2.0.3 deduped
+│   │ │ ├── mkdirp@0.5.1 deduped
+│   │ │ └── rimraf@2.6.2 deduped
+│   │ └── inherits@2.0.3
+│   └─┬ tar-pack@3.4.0
+│     ├─┬ debug@2.6.9
+│     │ └── ms@2.0.0
+│     ├── fstream@1.0.11 deduped
+│     ├─┬ fstream-ignore@1.0.5
+│     │ ├── fstream@1.0.11 deduped
+│     │ ├── inherits@2.0.3 deduped
+│     │ └── minimatch@3.0.4 deduped
+│     ├─┬ once@1.4.0
+│     │ └── wrappy@1.0.2
+│     ├─┬ readable-stream@2.3.3
+│     │ ├── core-util-is@1.0.2
+│     │ ├── inherits@2.0.3 deduped
+│     │ ├── isarray@1.0.0
+│     │ ├── process-nextick-args@1.0.7
+│     │ ├── safe-buffer@5.1.1 deduped
+│     │ ├─┬ string_decoder@1.0.3
+│     │ │ └── safe-buffer@5.1.1 deduped
+│     │ └── util-deprecate@1.0.2
+│     ├── rimraf@2.6.2 deduped
+│     ├── tar@2.2.1 deduped
+│     └── uid-number@0.0.6
+├── textextensions@2.2.0
+├─┬ through2@2.0.3
+│ ├── readable-stream@2.3.5 deduped
+│ └── xtend@4.0.1 deduped
+├─┬ unused-filename@0.1.0
+│ ├── modify-filename@1.1.0
+│ └── path-exists@3.0.0
+├─┬ utp-native@1.7.0
+│ ├── nan@2.8.0
+│ ├── node-gyp-build@3.3.0
+│ └── readable-stream@2.3.5 deduped
+├─┬ yo-yo@1.4.1
+│ ├── bel@4.6.0 deduped
+│ └── morphdom@2.3.3
+└── zerr@1.0.4
+

--- a/app/shell-window/ui/navbar.js
+++ b/app/shell-window/ui/navbar.js
@@ -25,6 +25,7 @@ const KEYCODE_ESC = 27
 const KEYCODE_ENTER = 13
 const KEYCODE_N = 78
 const KEYCODE_P = 80
+const KEYCODE_TAB = 9
 
 const isDatHashRegex = /^[a-z0-9]{64}/i
 const isIPAddressRegex = /^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/
@@ -837,8 +838,8 @@ function onKeydownLocation (e) {
   }
 
   // on keycode navigations
-  var up = (e.keyCode == KEYCODE_UP || (e.ctrlKey && e.keyCode == KEYCODE_P))
-  var down = (e.keyCode == KEYCODE_DOWN || (e.ctrlKey && e.keyCode == KEYCODE_N))
+  var up = (e.keyCode == KEYCODE_UP || (e.ctrlKey && e.keyCode == KEYCODE_P) || (e.shiftKey && e.keyCode == KEYCODE_TAB))
+  var down = (e.keyCode == KEYCODE_DOWN || (e.ctrlKey && e.keyCode == KEYCODE_N) || (!e.shiftKey && e.keyCode == KEYCODE_TAB))
   if (autocompleteResults && (up || down)) {
     e.preventDefault()
     if (up && autocompleteCurrentSelection > 0) { autocompleteCurrentSelection-- }


### PR DESCRIPTION
Other browsers allow to move up and down in their navbar autocomplete using Tab and Shift-Tab. This patch adds support for this in Beaker.