### PR TITLE
MIT License isn't modified

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ This project exists thanks to all the people who contribute. [[Contribute]](CONT
 
 ## License
 
-Modified MIT License (MIT)
+MIT License (MIT)
 
 Copyright (c) 2018 Blue Link Labs
 


### PR DESCRIPTION
Looks like the license was un-modified in https://github.com/beakerbrowser/beaker/commit/6c9304d0bfab15e77c6801ed21bd7a927e065bbf.