### PR TITLE
Only attempt to restore a window state from a previous session if it exists

### DIFF
--- a/app/background-process/ui/windows.js
+++ b/app/background-process/ui/windows.js
@@ -81,10 +81,12 @@ export async function setup () {
 
   if (!isTestDriverActive && (customStartPage === 'previous' || !previousSessionState.cleanExit && userWantsToRestoreSession())) {
     restoreBrowsingSession(previousSessionState)
-  } else {
+  } else if (previousSessionState.windows[0]) {
     // use the last session's window position
     let {x, y, width, height} = previousSessionState.windows[0]
     createShellWindow({x, y, width, height})
+  } else {
+    createShellWindow()
   }
 }
 


### PR DESCRIPTION
My `shell-window-state.json` contained only the following:

    {
      "windows": [],
      "cleanExit": true
    }

… causing an unhandled Promise rejection:

    Unhandled Rejection at: Promise Promise {
      <rejected> TypeError: Cannot destructure property `x` of 'undefined' or 'null'.
        at setup$4 (/home/rjkip/Projects/beaker/app/background-process.build.js:1789:61)
        at <anonymous> } reason: TypeError: Cannot destructure property `x` of 'undefined' or 'null'.
        at setup$4 (/home/rjkip/Projects/beaker/app/background-process.build.js:1789:61)
        at <anonymous>
    ^C