### PR TITLE
Implement find-next and find-previous shortcuts

### DIFF
--- a/app/background-process/ui/window-menu.js
+++ b/app/background-process/ui/window-menu.js
@@ -155,6 +155,20 @@ export function buildWindowMenu (opts = {}) {
         click: function (item, win) {
           if (win) win.webContents.send('command', 'edit:find')
         }
+      },
+      {
+        label: 'Find Next',
+        accelerator: 'CmdOrCtrl+G',
+        click: function (item, win) {
+          if (win) win.webContents.send('command', 'edit:find-next')
+        }
+      },
+      {
+        label: 'Find Previous',
+        accelerator: 'Shift+CmdOrCtrl+G',
+        click: function (item, win) {
+          if (win) win.webContents.send('command', 'edit:find-previous')
+        }
       }
     ]
   }

--- a/app/shell-window/command-handlers.js
+++ b/app/shell-window/command-handlers.js
@@ -18,6 +18,8 @@ export function setup () {
       case 'file:close-tab': return pages.remove(page)
       case 'file:reopen-closed-tab': return pages.reopenLastRemoved()
       case 'edit:find': return navbar.showInpageFind(page)
+      case 'edit:find-next': return navbar.findNext(page, true)
+      case 'edit:find-previous': return navbar.findNext(page, false)
       case 'view:reload': return page.reload()
       case 'view:hard-reload': return page.reloadIgnoringCacheAsync()
       case 'view:zoom-in': return zoom.zoomIn(page)

--- a/app/shell-window/ui/navbar.js
+++ b/app/shell-window/ui/navbar.js
@@ -102,6 +102,10 @@ export function showInpageFind (page) {
   el.select()
 }
 
+export function findNext(page, forward) {
+  onClickFindNext(forward)
+}
+
 export function hideInpageFind (page) {
   if (page.isInpageFinding) {
     page.stopFindInPageAsync('clearSelection')
@@ -214,8 +218,8 @@ function render (id, page) {
               </span>`
             : ''}
           <div class="nav-find-btns">
-            <button disabled=${!findValue} class="btn" onclick=${e => onClickFindNext(e, false)}><i class="fa fa-angle-up"></i></button>
-            <button disabled=${!findValue} class="btn last" onclick=${e => onClickFindNext(e, true)}><i class="fa fa-angle-down"></i></button>
+            <button disabled=${!findValue} class="btn" onclick=${e => onClickFindNext(false)}><i class="fa fa-angle-up"></i></button>
+            <button disabled=${!findValue} class="btn last" onclick=${e => onClickFindNext(true)}><i class="fa fa-angle-down"></i></button>
             <button class="close-btn" onclick=${e => hideInpageFind(page)}>${renderCloseIcon()}</button>
           </div>
         </div>
@@ -807,11 +811,10 @@ function onInputFind (e) {
   }
 }
 
-function onClickFindNext (e, forward) {
+function onClickFindNext (forward) {
   var page = pages.getActive()
   if (page) {
-    var wrapperEl = findParent(e.target, 'nav-find-wrapper')
-    var inputEl = wrapperEl.querySelector('input')
+    var inputEl = page.navbarEl.querySelector('.nav-find-input')
     var str = inputEl.value
     if (str) page.findInPageAsync(str, { findNext: true, forward })
   }


### PR DESCRIPTION
menu and keyboard shortcuts for find next (cmd+G) / previous (Shift+cmd+G). Remove the dependency on the click event, i assume there will only ever be one Find window in the ui so we can look it up directly.