### PR TITLE
Add a shortcut for focusing the address bar (alt + d).

### DIFF
--- a/app/background-process/ui/windows.js
+++ b/app/background-process/ui/windows.js
@@ -141,6 +141,7 @@ export function createShellWindow (windowState) {
   registerShortcut(win, 'Ctrl+PageDown', onNextTab(win))
   registerShortcut(win, 'CmdOrCtrl+[', onGoBack(win))
   registerShortcut(win, 'CmdOrCtrl+]', onGoForward(win))
+  registerShortcut(win, 'alt+d', onFocusLocation(win))
 
   // register event handlers
   win.on('browser-backward', onGoBack(win))
@@ -298,6 +299,10 @@ function onGoForward (win) {
   return () => win.webContents.send('command', 'history:forward')
 }
 
+function onFocusLocation (win) {
+  return () => win.webContents.send('command', 'file:open-location')
+}
+
 function onAppCommand (win, e, cmd) {
   // handles App Command events (Windows)
   // see https://electronjs.org/docs/all#event-app-command-windows
@@ -343,4 +348,3 @@ function sendScrollTouchBegin (e) {
 function getScreenAPI () {
   return require('electron').screen
 }
-


### PR DESCRIPTION
When using beaker browser, I find myself missing the alt + d shortcut to focus the address bar (which is available in firefox and chrome.)

While investigating what the situation is on Mac, I noticed there's an alternative 'ctrl + l' and that beaker implements that here: https://github.com/beakerbrowser/beaker/blob/bbed013686ddf0f8d78c9afbc8e4dbc3da3780d9/app/background-process/ui/window-menu.js#L108

(Oh, if I hold 'alt' I can see it labelled within the file menu.)

If you are interested in having the 'alt + d' shortcut as well, would you prefer that I instead either:

* Make it possible to define an accelerator of the form 'CmdOrCtrl+LOrAlt+d'
* Make it possible to define an array of accelerators in the menus ?

Or is this pull request fine as is?