### PR TITLE
applies min height/width to browser window

### DIFF
--- a/app/background-process/ui/default-state.js
+++ b/app/background-process/ui/default-state.js
@@ -15,11 +15,15 @@ export function defaultWindowState () {
   var bounds = screen ? screen.getPrimaryDisplay().bounds : {width: 800, height: 600}
   var width = Math.max(800, Math.min(1800, bounds.width - 50))
   var height = Math.max(600, Math.min(1200, bounds.height - 50))
+  var minWidth = 400;
+  var minHeight = 300;
   return {
     x: (bounds.width - width) / 2,
     y: (bounds.height - height) / 2,
     width,
     height,
+    minWidth,
+    minHeight,
     pages: defaultPageState()
   }
 }

--- a/app/background-process/ui/windows.js
+++ b/app/background-process/ui/windows.js
@@ -105,7 +105,7 @@ export async function setup () {
 export function createShellWindow (windowState) {
   // create window
   let state = ensureVisibleOnSomeDisplay(Object.assign({}, defaultWindowState(), windowState))
-  var { x, y, width, height } = state
+  var { x, y, width, height, minWidth, minHeight } = state
   var win = new BrowserWindow({
     titleBarStyle: 'hiddenInset',
     autoHideMenuBar: true,
@@ -116,6 +116,8 @@ export function createShellWindow (windowState) {
     y,
     width,
     height,
+    minWidth,
+    minHeight,
     defaultEncoding: 'UTF-8',
     webPreferences: {
       webSecurity: false, // disable same-origin-policy in the shell window, webviews have it restored


### PR DESCRIPTION
i tend to shrink the browser width to test css media queries and noticed that beaker can get quite small. went ahead and added some reasonable `minWidth` and `minHeight` values to the `BrowserWindow`. 

before:
<img width="79" alt="beaker_and_workspace" src="https://user-images.githubusercontent.com/5317799/39738982-44efe84a-5243-11e8-9637-82a964009627.png">

after:
<img width="401" alt="beaker_and_beaker" src="https://user-images.githubusercontent.com/5317799/39739057-bc94a354-5243-11e8-9b3b-4d3e2843199e.png">
