### PR TITLE
Exclude unused native binaries from builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,12 @@
   },
   "build": {
     "appId": "com.pfrazee.beaker-browser",
+    "files": [
+      "**/*",
+      "!node_modules/**/sodium-native/prebuilds/**/*",
+      "node_modules/**/sodium-native/prebuilds/${platform}-${arch}/libsodium.*",
+      "node_modules/**/sodium-native/prebuilds/${platform}-${arch}/node-*"
+    ],
     "asar": true,
     "asarUnpack": [
       "./node_modules/sodium-native/**"

--- a/package.json
+++ b/package.json
@@ -30,13 +30,16 @@
     "appId": "com.pfrazee.beaker-browser",
     "files": [
       "**/*",
-      "!node_modules/**/sodium-native/prebuilds/**/*",
-      "node_modules/**/sodium-native/prebuilds/${platform}-${arch}/libsodium.*",
-      "node_modules/**/sodium-native/prebuilds/${platform}-${arch}/node-*"
+      "!**/node_modules/sodium-native/libsodium",
+      "!**/node_modules/sodium-native/prebuilds/!(${platform}-${arch})",
+      "!**/node_modules/sodium-native/prebuilds/${platform}-${arch}/!(node*|libsodium*)",
+      "!**/node_modules/utp-native/deps",
+      "!**/node_modules/utp-native/prebuilds/!(${platform}-${arch})",
+      "!**/node_modules/utp-native/prebuilds/${platform}-${arch}/!(node*)"
     ],
     "asar": true,
     "asarUnpack": [
-      "./node_modules/sodium-native/**"
+      "./node_modules/sodium-native"
     ],
     "copyright": "© 2018, Blue Link Labs",
     "npmRebuild": false,


### PR DESCRIPTION
Release builds are including all platform binaries for sodium-native which adds a lot to the build size. This change includes only binaries for the current platform.

```bash
# Before change
~/projects/beaker (master) $ du -sh ./dist/mac/Beaker\ Browser.app/
240M    ./dist/mac/Beaker Browser.app/

# After change
~/projects/beaker (master) $ du -sh ./dist/mac/Beaker\ Browser.app/
225M    ./dist/mac/Beaker Browser.app/
```

It looks like Beaker only uses sodium-native within the background process so only the node binaries are required. I wasn't sure which ABI version is needed so it still includes all node binary versions for the platform.

Note that I've only tested this on macOS.