### PR TITLE
Add DatArchive#checkout() method

### DIFF
--- a/app/builtin-pages/com/archive-history.js
+++ b/app/builtin-pages/com/archive-history.js
@@ -15,12 +15,9 @@ export default function render (archive) {
 
   // lazy-load history
   if (archive) {
-    // strip the version
-    let vi = archive.url.indexOf('+')
-    if (vi !== -1) {
-      archive = new DatArchive(archive.url.slice(0, vi))
-    }
-
+    // read from latest
+    archive = archive.checkout()
+    
     let history = []
     fetchMore()
     async function fetchMore () {

--- a/app/lib/web-apis/dat-archive.js
+++ b/app/lib/web-apis/dat-archive.js
@@ -117,6 +117,12 @@ class DatArchive extends EventTarget {
     }
   }
 
+  checkout (version) {
+    const urlParsed = parseDatURL(this.url)
+    version = typeof version === 'number' ? `+${version}` : ''
+    return new DatArchive(`dat://${urlParsed.hostname}${version}`)
+  }
+
   async diff (opts = {}) {
     // noop
     console.warn('The DatArchive diff() API has been deprecated.')


### PR DESCRIPTION
Currently, if you want to access a specific revision of an archive, you have to manipulate the URL. This snippet is an example of what this is like:

```js
// read from latest
let vi = archive.url.indexOf('+')
if (vi !== -1) {
  archive = new DatArchive(archive.url.slice(0, vi))
}
```

This PR adds a `checkout()` method to the `DatArchive` which makes it easy to do this. If no number is passed in, you will get latest. Examples:

```js
var v5 = archive.checkout(5) // get revision 5
var latest = archive.checkout() // get latest
await archive.checkout(5).readdir('/') // read the files listing at root of revision 5
```