### PR TITLE
Add experimental.globalFetch() Labs API

### DIFF
--- a/app/background-process/web-apis.js
+++ b/app/background-process/web-apis.js
@@ -29,12 +29,13 @@ import datArchiveAPI from './web-apis/dat-archive'
 // import userSessionAPI from './web-apis/user-session'
 // import profilesAPI from './web-apis/profiles'
 
-
 // experimental manifests
 import experimentalLibraryManifest from '../lib/api-manifests/external/experimental/library'
+import experimentalGlobalFetchManifest from '../lib/api-manifests/external/experimental/global-fetch'
 
 // experimental apis
 import experimentalLibraryAPI from './web-apis/experimental/library'
+import experimentalGlobalFetchAPI from './web-apis/experimental/global-fetch'
 
 // exported api
 // =
@@ -56,4 +57,5 @@ export function setup () {
 
   // experimental apis
   rpc.exportAPI('experimental-library', experimentalLibraryManifest, experimentalLibraryAPI, secureOnly)
+  rpc.exportAPI('experimental-global-fetch', experimentalGlobalFetchManifest, experimentalGlobalFetchAPI, secureOnly)
 }

--- a/app/background-process/web-apis/experimental/global-fetch.js
+++ b/app/background-process/web-apis/experimental/global-fetch.js
@@ -1,0 +1,68 @@
+import http from 'http'
+import https from 'https'
+import concat from 'concat-stream'
+import {URL} from 'url'
+import {checkLabsPerm} from '../../ui/permissions'
+
+// constants
+// =
+
+const API_DOCS_URL = 'https://TODO' // TODO
+const API_PERM_ID = 'experimentalGlobalFetch'
+const LAB_API_ID = 'globalFetch'
+
+// exported api
+// =
+
+export default {
+  async fetch (reqOptions, reqBody) {
+    // parse url
+    var urlp = new URL(reqOptions.url)
+    reqOptions.protocol = urlp.protocol
+    reqOptions.host = urlp.host
+    reqOptions.path = urlp.pathname + urlp.search + urlp.hash
+
+    if (reqOptions.protocol !== 'https:' && reqOptions.protocol !== 'http:') {
+      throw new Error('Can only send requests to http or https URLs')
+    }
+
+    // check perms
+    await checkLabsPerm({
+      perm: API_PERM_ID + ':' + reqOptions.protocol + '//' + reqOptions.host,
+      labApi: LAB_API_ID,
+      apiDocsUrl: API_DOCS_URL,
+      sender: this.sender
+    })
+
+    return new Promise((resolve, reject) => {
+      // start request
+      var proto = urlp.protocol === 'https:' ? https : http
+      var reqStream = proto.request(reqOptions, resStream => {
+        resStream.pipe(concat(resStream, resBody => {
+          // resolve with response
+          resolve({
+            status: resStream.statusCode,
+            statusText: resStream.statusMessage,
+            headers: resStream.headers,
+            body: resBody
+          })
+        }))
+
+        // handle errors
+        resStream.on('error', err => {
+          reject(new Error('Network request failed'))
+        })
+        resStream.on('abort', err => {
+          reject(new Error('Aborted'))
+        })
+      })
+
+      // send data
+      if (reqBody) {
+        reqStream.send(reqBody)
+      }
+
+      reqStream.end()
+    })
+  }
+}

--- a/app/lib/api-manifests/external/experimental/global-fetch.js
+++ b/app/lib/api-manifests/external/experimental/global-fetch.js
@@ -1,0 +1,3 @@
+export default {
+  fetch: 'promise'
+}

--- a/app/lib/perms.js
+++ b/app/lib/perms.js
@@ -173,5 +173,16 @@ export default {
     alwaysDisallow: false,
     requiresRefresh: false,
     experimental: true
+  },
+  experimentalGlobalFetch: {
+    desc: (param, pages, opts = {}) => {
+      const viewPage = () => pages.setActive(pages.create(param))
+      return yo`<span>Fetch data from <a onclick=${viewPage}>${param}</a></span>`
+    },
+    icon: 'download',
+    persist: true,
+    alwaysDisallow: false,
+    requiresRefresh: false,
+    experimental: true
   }
 }

--- a/app/lib/web-apis/experimental.js
+++ b/app/lib/web-apis/experimental.js
@@ -3,6 +3,7 @@ import {EventTargetFromStream} from './event-target'
 import errors from 'beaker-error-constants'
 
 import experimentalLibraryManifest from '../api-manifests/external/experimental/library'
+import experimentalGlobalFetchManifest from '../api-manifests/external/experimental/global-fetch'
 
 const experimental = {}
 const opts = {timeout: false, errors}
@@ -10,6 +11,7 @@ const opts = {timeout: false, errors}
 // dat or internal only
 if (window.location.protocol === 'beaker:' || window.location.protocol === 'dat:') {
   const libraryRPC = rpc.importAPI('experimental-library', experimentalLibraryManifest, opts)
+  const globalFetchRPC = rpc.importAPI('experimental-global-fetch', experimentalGlobalFetchManifest, opts)
 
   // experimental.library
   let libraryEvents = ['added', 'removed', 'updated', 'folder-synced', 'network-changed']
@@ -20,6 +22,20 @@ if (window.location.protocol === 'beaker:' || window.location.protocol === 'dat:
   experimental.library.list = libraryRPC.list
   experimental.library.requestAdd = libraryRPC.requestAdd
   experimental.library.requestRemove = libraryRPC.requestRemove
+
+  // experimental.globalFetch
+  experimental.globalFetch = async function globalFetch (input, init) {
+    var request = new Request(input, init)
+    if (request.method !== 'HEAD' && request.method !== 'GET') {
+      throw new Error('Only HEAD and GET requests are currently supported by globalFetch()')
+    }
+    var responseData = await globalFetchRPC.fetch({
+      method: request.method,
+      url: request.url,
+      headers: request.headers
+    })
+    return new Response(responseData.body, responseData)
+  }
 }
 
 export default experimental

--- a/tests/experimental-global-fetch-web-api-test.js
+++ b/tests/experimental-global-fetch-web-api-test.js
@@ -1,0 +1,96 @@
+import test from 'ava'
+import os from 'os'
+import path from 'path'
+import fs from 'fs'
+import tempy from 'tempy'
+import jetpack from 'fs-jetpack'
+import electron from '../node_modules/electron'
+
+import * as browserdriver from './lib/browser-driver'
+import {waitForSync, escapeWindowsSlashes} from './lib/test-helpers'
+import {swarmDat, shareDat} from './lib/dat-helpers'
+
+const app = browserdriver.start({
+  path: electron,
+  args: ['../app'],
+  env: {
+    NODE_ENV: 'test',
+    beaker_no_welcome_tab: 1,
+    beaker_user_data_path: fs.mkdtempSync(os.tmpdir() + path.sep + 'beaker-test-')
+  }
+})
+var createdDatUrl
+var createdFilePath = tempy.directory()
+var mainTab
+
+test.before(async t => {
+  await app.isReady
+
+  // create the test archive
+  var res = await app.executeJavascript(`
+    DatArchive.create({title: 'Test Archive', description: 'Foo', prompt: false})
+  `)
+  createdDatUrl = res.url
+
+  // set the sync folder
+  var onSync = waitForSync(app, createdDatUrl, 'folder')
+  var res = await app.executeJavascript(`
+    beaker.archives.setLocalSyncPath("${createdDatUrl}", "${escapeWindowsSlashes(createdFilePath)}")
+  `)
+  t.falsy(res)
+  await onSync
+
+  // go to the site
+  mainTab = app.getTab(0)
+  await mainTab.navigateTo(createdDatUrl)
+})
+test.after.always('cleanup', async t => {
+  await app.stop()
+})
+
+// tests
+//
+
+test('experiment must be opted into', async t => {
+  // try without experiment set
+  try {
+    await mainTab.executeJavascript(`
+      experimental.globalFetch('https://example.com')
+    `)
+    t.fail('Should have thrown')
+  } catch (e) {
+    t.is(e.name, 'PermissionsError')
+  }
+
+  // update manifest to include experiment
+  var dir = jetpack.cwd(createdFilePath)
+  var manifest = await dir.readAsync('dat.json', 'json')
+  manifest.experimental = {apis: ['globalFetch']}
+  await dir.writeAsync('dat.json', manifest)
+  await waitForSync(app, createdDatUrl, 'archive')
+})
+
+test('globalFetch()', async t => {
+  // fetch https://example.com (first call)
+  var page = mainTab.executeJavascript(`
+    experimental.globalFetch('https://example.com').then(res => res.text())
+  `)
+
+  // accept the permission prompt
+  await app.waitForElement('.prompt-accept')
+  await app.click('.prompt-accept')
+  page = await page
+
+  // check results
+  t.is(typeof page, 'string')
+  t.truthy(page.trim().startsWith('<!doctype html>'))
+
+  // fetch https://example.com (second call)
+  var page = await mainTab.executeJavascript(`
+    experimental.globalFetch('https://example.com').then(res => res.text())
+  `)
+
+  // check results
+  t.is(typeof page, 'string')
+  t.truthy(page.trim().startsWith('<!doctype html>'))
+})


### PR DESCRIPTION
Traditional web applications are able to make cross-origin requests by proxying through their own servers. That's not a possibility for Dat's serverless apps, which is a problem for a lot of apps. For instance, what if you wanted to fetch "open graph" metadata for a site before posting it on a social profile app (ie fritter).

This PR solves this issue with a new Labs API called `experimental.globalFetch`. It is functionally similar to `fetch()` except for a few key differences:

 - Currently only `HEAD` and `GET` are supported.
 - A permission prompt is raised for each request to a new origin.
 - CORS policies are not applied, and so the site can send a request to any possible service.
 - Cookies/credentials are never sent.

For each new origin contacted, a new permission prompt will be created:

![screen shot 2018-06-09 at 5 41 06 pm](https://user-images.githubusercontent.com/1270099/41196680-5a3b49c8-6c0c-11e8-9ce4-c58297d22a56.png)

The permission will persist for every origin.

To use this API, add the `globalFetch` token to the `experimental.apis` array in the dat.json manifest:

```json
{
  "experimental": {
    "apis": ["globalFetch"]
  }
}
```

You can then use the API exactly as [Fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch) is used:

```js
var res = await experimental.globalFetch('https://beakerbrowser.com/about.html')
var body = await res.text()
```