### PR TITLE
Donate dropdown overflows with long URLs

### DIFF
--- a/app/stylesheets/shell-window/donate-menu-dropdown.less
+++ b/app/stylesheets/shell-window/donate-menu-dropdown.less
@@ -27,5 +27,6 @@
   .body {
     margin: 0 10px;
     padding: 10px 0;
+    overflow-wrap: break-word;
   }
 }


### PR DESCRIPTION
This isn't really a complete fix, it'll still look a bit wild on screen but it should keep the URL from escaping the dropdown for the Donate button (I tested the feature with a dat:// URL to come across this bug).

Could've used "word-break: break-word" or "overflow: hidden" instead but that's a design thing and I'm not sure I've good input to share there.