### PR TITLE
fix(archive-history): Use an anchor tag for archive-history-items

### DIFF
--- a/app/builtin-pages/com/archive-history.js
+++ b/app/builtin-pages/com/archive-history.js
@@ -30,9 +30,7 @@ export default function render (archive) {
         // render
         var rowEls = history.map(c => (
           yo`
-            <div
-              onclick=${() => window.location = `beaker://library/${archive.url}+${c.version}`}
-              class="archive-history-item"
+            <a class="archive-history-item"
               title="View version ${c.version}"
               href="beaker://library/${archive.url}+${c.version}"
             >
@@ -45,7 +43,7 @@ export default function render (archive) {
               </div>
 
               <div class="version badge green">v${c.version}</div>
-            </div>`
+            </a>`
         ))
 
         yo.update(el, yo`

--- a/app/stylesheets/builtin-pages/components/archive-history.less
+++ b/app/stylesheets/builtin-pages/components/archive-history.less
@@ -34,6 +34,8 @@
     padding: 0 10px;
     border-bottom: 1px solid #eee;
     cursor: pointer;
+    text-decoration: none;
+    color: black !important;
 
     .version {
       &:extend(.code-font);
@@ -50,6 +52,8 @@
 
     &:hover {
       background: #f0f0f0;
+      text-decoration: none;
+      color: black !important;
     }
   }
 }


### PR DESCRIPTION
The current implementation uses a div with `onclick` and `href` without `role='button'` (or equivalent). I think this is a more correct implementation of that. Let me know if it makes sense. I only tested this in devtools, since I can't build beaker ATM (see freenode channel).

Not sure if overriding the default `a` styles is the best way, maybe there is already code to do this better?