### PR TITLE
Add libXScrnSaver dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ In Linux (and in some cases macOS) you need libtool, m4, and automake:
 
 ```bash
 sudo apt-get install libtool m4 make g++  # debian/ubuntu
-sudo dnf install libtool m4 make gcc-c++  # fedora
+sudo dnf install libtool m4 make gcc-c++ libXScrnSaver  # fedora
 ```
 
 In Windows, you'll need to install [Python 2.7](https://www.python.org/downloads/release/python-2711/), Visual Studio 2015 or 2017, and [Git](https://git-scm.com/download/win). (You might try [windows-build-tools](https://www.npmjs.com/package/windows-build-tools).) Then run:


### PR DESCRIPTION
I was installing Beaker Browser in a clean install of Fedora and ran into an error that took me a bit to locate. I didn't realize I already had this dependency in my previous install, so this PR is to help new users on Fedora :smile_cat: 

Note: I ran `npm burnthemall`, `npm install` and `npm run rebuild` before I found this missing dependency. Installing this dependency helped resolve the issue in the screenshot below

![screenshot from 2018-08-03 11-21-09](https://user-images.githubusercontent.com/2946344/43635520-9ddd0dbe-970f-11e8-90cc-8aefd9e55b85.png)
