### PR TITLE
Full-height tabs in maximised win32 windows

### DIFF
--- a/app/background-process/ui/windows.js
+++ b/app/background-process/ui/windows.js
@@ -189,6 +189,8 @@ export function createShellWindow (windowState) {
     unregisterShortcut(win, 'Esc')
     sendToWebContents('leave-full-screen')(e)
   })
+  win.on('maximize', sendToWebContents('maximize'))
+  win.on('unmaximize', sendToWebContents('unmaximize'))
   win.on('closed', onClosed(win))
 
   return win

--- a/app/shell-window/ui.js
+++ b/app/shell-window/ui.js
@@ -61,6 +61,8 @@ function onWindowEvent (event, type) {
       break
     case 'enter-full-screen': return document.body.classList.add('fullscreen')
     case 'leave-full-screen': return document.body.classList.remove('fullscreen')
+    case 'maximize': return document.body.classList.add('maximized')
+    case 'unmaximize': return document.body.classList.remove('maximized')    
     case 'leave-page-full-screen': pages.leavePageFullScreen()
   }
 }

--- a/app/stylesheets/shell-window/chrome-tabs.less
+++ b/app/stylesheets/shell-window/chrome-tabs.less
@@ -257,8 +257,8 @@ body.darwin .chrome-tabs {
   -webkit-app-region: drag;
 }
 
-// make room for resizing on the top
-body.win32 {
+// make room for resizing on the top when not maximized.
+body:not(.maximized).win32{
   .chrome-tabs-shell {
     padding-top: 4px;
   }
@@ -269,6 +269,17 @@ body.win32 {
     .chrome-tab {
       top: 2px;
     }
+  }
+}
+
+// Ensure tabs go right to top of screen when maximized on win32.
+body.maximized.win32 {
+  .chrome-tab {
+    top: 0px;
+  }
+
+  .chrome-tabs-shell {
+    height: 30px;
   }
 }
 

--- a/app/stylesheets/shell-window/toolbar.less
+++ b/app/stylesheets/shell-window/toolbar.less
@@ -22,6 +22,11 @@ body.fullscreen #toolbar {
   background: #e0e0e0;
 }
 
+// Ensure toolbar resizes correctly when maximized on win32.
+body.maximized.win32 {
+  height: 68px;
+}
+
 .download-started-animation {
   position: fixed;
   bottom: 20px;

--- a/app/stylesheets/shell-window/win32-titlebar.less
+++ b/app/stylesheets/shell-window/win32-titlebar.less
@@ -62,3 +62,14 @@
 body.win32 #win32-titlebar {
   display: flex;
 }
+
+// Ensure that the controls are properly sized when maximized.
+body.maximized.win32 {
+  #win32-titlebar {
+    height: 30px;
+  }
+  
+  #win32-titlebar .win32-titlebar-close:after {
+    line-height: 30px;
+  }
+}


### PR DESCRIPTION
Makes sure that tabs on maximised win32 windows go all the way to the top (like they do in Chrome, Firefox, Edge).  This hugely improves usability since you cannot overshoot the tab.  Hopefully resolves #1105 