### PR TITLE
Make restore session dialog more understandable

### DIFF
--- a/app/background-process/ui/windows.js
+++ b/app/background-process/ui/windows.js
@@ -245,7 +245,7 @@ function userWantsToRestoreSession () {
     type: 'question',
     message: 'Sorry! It looks like Beaker crashed',
     detail: 'Would you like to restore your previous browsing session?',
-    buttons: [ 'Restore Session', 'Cancel' ],
+    buttons: [ 'Restore Session', 'Start New Session' ],
     defaultId: 0,
     icon: ICON_PATH
   })


### PR DESCRIPTION
"Restore session" vs "Cancel" is confusing if you are not familiar with the software - it felt like it was going to cancel loading the app.  This makes it clearer what the choices are I think.