### PR TITLE
Enable rubber band scrolling on <webview> elements

### DIFF
--- a/app/shell-window/pages.js
+++ b/app/shell-window/pages.js
@@ -1078,8 +1078,7 @@ export function createWebviewEl (id, url) {
   var el = document.createElement('webview')
   el.dataset.id = id
   el.setAttribute('preload', 'file://' + path.join(APP_PATH, 'webview-preload.build.js'))
-  el.setAttribute('webpreferences', 'allowDisplayingInsecureContent,defaultEncoding=utf-8')
-  // TODO add scrollBounce^ after https://github.com/electron/electron/issues/9233 is fixed
+  el.setAttribute('webpreferences', 'allowDisplayingInsecureContent,defaultEncoding=utf-8,scrollBounce')
   // TODO re-enable nativeWindowOpen when https://github.com/electron/electron/issues/9558 lands
   el.setAttribute('src', url || DEFAULT_URL)
   return el


### PR DESCRIPTION
Closes #704

This PR adds support for rubber band scrolling (#704). 

### Reason

According to a `TODO` comment in the source code, this was meant to be fixed when issue https://github.com/electron/electron/issues/9233 was resolved. Although the issue has not been marked as `closed` there are comments that say that the issue is no longer a problem in Electron `2.0.0`

https://github.com/beakerbrowser/beaker/blob/73461db7cf790518f9b3e52b015f772164a19f68/app/shell-window/pages.js#L1082

### Tests

![demo](https://media.giphy.com/media/fH0qNEQAwPmZSeQgF2/giphy.gif)

> Rubber band scrolling is working as expected now.

### Fix details

Added `scrollBounce` to `<webview>` `webpreferences` attribute in `createWebviewEl`