### PR TITLE
Added in feature to upload a favicon

### DIFF
--- a/app/background-process/browser.js
+++ b/app/background-process/browser.js
@@ -207,11 +207,11 @@ export async function uploadFavicon () {
   let extension = path.extname(favicon[0])
 
   if (extension === '.png') {
-    return toIco(faviconBuffer)
+    return toIco(faviconBuffer, {resize: true})
   }
   if (extension === '.jpg') {
     let imageToPng = nativeImage.createFromBuffer(faviconBuffer).toPNG()
-    return toIco(imageToPng)
+    return toIco(imageToPng, {resize: true})
   }
   if (extension === '.ico' && ICO.isICO(faviconBuffer)) {
     return faviconBuffer

--- a/app/background-process/browser.js
+++ b/app/background-process/browser.js
@@ -1,11 +1,13 @@
 import * as beakerCore from '@beaker/core'
-import {app, dialog, BrowserWindow, webContents, ipcMain, shell, Menu, screen, session} from 'electron'
+import {app, dialog, BrowserWindow, webContents, ipcMain, shell, Menu, screen, session, nativeImage} from 'electron'
 import {autoUpdater} from 'electron-updater'
 import os from 'os'
 import path from 'path'
 import fs from 'fs'
 import slugify from 'slugify'
 import jetpack from 'fs-jetpack'
+import ICO from 'icojs'
+import toIco from 'to-ico'
 import emitStream from 'emit-stream'
 import EventEmitter from 'events'
 import LRU from 'lru'
@@ -131,6 +133,7 @@ export const WEBAPI = {
 
   listBuiltinFavicons,
   getBuiltinFavicon,
+  uploadFavicon,
 
   setWindowDimensions,
   showOpenDialog,
@@ -185,6 +188,34 @@ export async function listBuiltinFavicons ({filter, offset, limit} = {}) {
 export async function getBuiltinFavicon (name) {
   var dir = jetpack.cwd(__dirname).cwd('assets/favicons')
   return dir.readAsync(name, 'buffer')
+}
+
+export async function uploadFavicon () {
+  let favicon = dialog.showOpenDialog({
+    title: 'Upload Favicon...',
+    defaultPath: app.getPath('home'),
+    buttonLabel: 'Upload Favicon',
+    filters: [
+      { name: 'Images', extensions: ['png', 'ico', 'jpg'] }
+    ],
+    properties: ['openFile']
+  })
+
+  if (!favicon) return
+
+  let faviconBuffer = await jetpack.readAsync(favicon[0], 'buffer')
+  let extension = path.extname(favicon[0])
+
+  if (extension === '.png') {
+    return toIco(faviconBuffer)
+  }
+  if (extension === '.jpg') {
+    let imageToPng = nativeImage.createFromBuffer(faviconBuffer).toPNG()
+    return toIco(imageToPng)
+  }
+  if (extension === '.ico' && ICO.isICO(faviconBuffer)) {
+    return faviconBuffer
+  }
 }
 
 export async function setWindowDimensions ({width, height} = {}) {

--- a/app/builtin-pages/com/settings/favicon-picker.js
+++ b/app/builtin-pages/com/settings/favicon-picker.js
@@ -84,6 +84,7 @@ async function onClickRemove () {
 }
 
 async function uploadFavicon () {
-  onSelect(await beaker.browser.uploadFavicon())
+  let v = await beaker.browser.uploadFavicon()
+  if (v) onSelect(v)
   rerender()
 }

--- a/app/builtin-pages/com/settings/favicon-picker.js
+++ b/app/builtin-pages/com/settings/favicon-picker.js
@@ -55,8 +55,9 @@ function render () {
           </div>
         `)}
       </div>
-      <div class="remove">
+      <div class="tools">
         <a class="btn plain" onclick=${() => onClickRemove()}><span class="fa fa-times"></span> remove favicon</a>
+        <a class="btn plain" onclick=${() => uploadFavicon()}><span class="fa fa-upload"></span> upload a favicon</a>
       </div>
     </div>
   `
@@ -79,5 +80,10 @@ async function onClickIcon (v) {
 async function onClickRemove () {
   selectedFavicon = null
   onSelect(null)
+  rerender()
+}
+
+async function uploadFavicon () {
+  onSelect(await beaker.browser.uploadFavicon())
   rerender()
 }

--- a/app/package.json
+++ b/app/package.json
@@ -86,6 +86,7 @@
     "split2": "^2.2.0",
     "textextensions": "^2.2.0",
     "through2": "^2.0.1",
+    "to-ico": "^1.1.5",
     "unused-filename": "^0.1.0",
     "utp-native": "^2.0.0",
     "yo-yo": "^1.4.0",

--- a/app/stylesheets/builtin-pages/components/favicon-picker.less
+++ b/app/stylesheets/builtin-pages/components/favicon-picker.less
@@ -36,12 +36,14 @@
     }
   }
 
-  .remove {  
+  .tools {  
     border-top: 1px solid #ddd;
     height: 24px;
     margin-top: 6px;
     padding-top: 2px;
     font-size: 12px;
+    display: flex;
+    justify-content: space-between;
 
     a {
       font-size: 11px;


### PR DESCRIPTION
Had to add a new package `'to-ico'` in order to convert `.png` files to `.ico` format
Added button inside of favion picker to upload favicon. This opens a dialog to choose the favicon file. Limited to `.jpg`, `.png`, and `.ico`.