### PR TITLE
Fix to #1214

### DIFF
--- a/app/builtin-pages/views/library-view.js
+++ b/app/builtin-pages/views/library-view.js
@@ -1733,7 +1733,13 @@ async function onDeleteFile (e) {
   }
 }
 
-function onOpenFileEditor (e) {
+async function onOpenFileEditor () {
+  var currentNode = filesBrowser.getCurrentSource()
+  if (currentNode) {
+    await currentNode.readData({ignoreCache: true})
+    setAceValue(currentNode.preview)
+  }
+
   // update the UI
   filesBrowser.isEditMode = true
   render()

--- a/app/package.json
+++ b/app/package.json
@@ -15,7 +15,7 @@
     "await-lock": "^1.1.3",
     "beaker-error-constants": "^1.4.0",
     "beaker-profiles-api": "^2.4.2",
-    "beaker-virtual-fs": "git://github.com/beakerbrowser/beaker-virtual-fs.git#6e6afcc9010dfa7ff28a74dcf437f22f0ab5908c",
+    "beaker-virtual-fs": "git://github.com/beakerbrowser/beaker-virtual-fs.git#78bb2f0b65bb6cc62472d0358fb133a7d86aa6be",
     "binary-extensions": "^1.10.0",
     "builtin-pages-lib": "git://github.com/beakerbrowser/builtin-pages-lib.git#e6c36086fb85d14325b4db5196f1aa1b68cf9e90",
     "bytes": "^2.5.0",


### PR DESCRIPTION
Renders a preview max `1e5` (100,000 bytes) in size. When you click the pencil and enter edit mode, the full file will be shown in the editor. Not showing on initial viewing to prevent rendering a large file.