### PR TITLE
Quick fix to library search

### DIFF
--- a/app/builtin-pages/views/library.js
+++ b/app/builtin-pages/views/library.js
@@ -102,7 +102,7 @@ function filterArchives () {
         return a
       } else if (a.description && a.description.toLowerCase().includes(query)) {
         return a
-      } else if (a.key && a.key.toLowerCase().includes(query)) {
+      } else if (a.url && a.url.toLowerCase().includes(query)) {
         return a
       }
     })


### PR DESCRIPTION
Allow dat:// to be apart of the dat key search.
Now works with just keys or dat://key