### PR TITLE
Builtin pages lose focus after navigation

### DIFF
--- a/app/shell-window/pages.js
+++ b/app/shell-window/pages.js
@@ -614,6 +614,8 @@ function onDomReady (e) {
     }
     if (!navbar.isLocationFocused(page) && page.isActive) {
       page.webviewEl.shadowRoot.querySelector('iframe').focus()
+      page.webviewEl.blur()
+      page.webviewEl.focus()
     }
   }
 }


### PR DESCRIPTION
On Beaker 0.8.2 I've noticed the builtin pages intermittently lose focus when navigating between them. Focusing another UI element in Beaker, and then clicking back in restores the focus. 

Here's a gif to illustrate what I mean:

![beaker-webview-loses-focus](https://user-images.githubusercontent.com/679312/50057358-256c1e00-011e-11e9-9587-72cf62a21c0c.gif)

I think this is a case of https://github.com/electron/electron/issues/14474

In this PR I'm following the workaround discussed in the electron issue, calling the webview's blur/focus methods on domready. This fixes the problem for me, autofocus works properly and I can navigate around the forms as expected.
