### PR TITLE
Use tabular numbers for address bar peer counter

### DIFF
--- a/app/stylesheets/shell-window/toolbar-input-group.less
+++ b/app/stylesheets/shell-window/toolbar-input-group.less
@@ -94,6 +94,7 @@
     &.nav-peers-btn {
       height: 100%;
       font-size: 12.5px;
+      font-variant-numeric: tabular-nums;
       color: fadeout(black, 50%);
 
       i {
@@ -308,7 +309,7 @@
   .nav-location-pretty {
     &:extend(.overflow-ellipsis);
     position: absolute;
-    top: 0; 
+    top: 0;
     left: 0;
     width: ~"calc(100% - 16px)"; // -16 to counter the padding on the input
     height: 25px;


### PR DESCRIPTION
Ref #1289 

This is just a one-liner to use tabular (fixed width) numbers for the peer counter. It was buggin' me too!

![fixed-width-yo](https://user-images.githubusercontent.com/679312/50412690-5bfd0500-07be-11e9-87cd-cb55e9e9c765.gif)

Now the counter will only change width when the number of digits changes. Happy holidays!
