### PR TITLE
Make website template use relative asset URIs

### DIFF
--- a/app/assets/templates/app/index.html
+++ b/app/assets/templates/app/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>Hello world!</title>
-    <link rel="stylesheet" href="/styles.css">
+    <link rel="stylesheet" href="styles.css">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
   </head>

--- a/app/assets/templates/website/index.html
+++ b/app/assets/templates/website/index.html
@@ -9,7 +9,7 @@
   <head>
     <meta charset="utf-8">
     <title>Hello world!</title>
-    <link rel="stylesheet" href="/styles.css">
+    <link rel="stylesheet" href="styles.css">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
   </head>


### PR DESCRIPTION
This PR changes the templates for new Dat sites to use relative paths.

I think it's important to encourage people composing sites in Beaker to use relative paths for assets at all times. Specifically with things like `homebase`, I can make an https mirroring service that mirrors these sites from any subdirectory of a pinning host. This would break a site with absolute paths but a site with relative paths would still work. Obviously we can't enforce this coding style but encouraging it by providing this style in the template is a start.

(The js file listed in the website template already uses a relative path so I didn't have to change it.)