### PR TITLE
Add View > Full Screen menu item

### DIFF
--- a/app/background-process/ui/window-menu.js
+++ b/app/background-process/ui/window-menu.js
@@ -333,6 +333,13 @@ export function buildWindowMenu (opts = {}) {
         click: function (item, win) {
           if (win) win.webContents.send('command', 'view:toggle-live-reloading')
         }
+      },
+      { type: 'separator' },
+      {
+        label: 'Full Screen',
+        enabled: !noWindows,
+        accelerator: (process.platform === 'darwin') ? 'Ctrl+Cmd+F' : 'F11',
+        role: 'toggleFullScreen'
       }]
   }
 

--- a/app/stylesheets/shell-window/chrome-tabs.less
+++ b/app/stylesheets/shell-window/chrome-tabs.less
@@ -269,7 +269,7 @@ body.win32 {
 
   .chrome-tabs {
     height: 32px;
-    
+
     .chrome-tab {
       top: 2px;
     }
@@ -294,6 +294,14 @@ body.win32 {
 .fullscreen {
   .chrome-tab:hover:not(.chrome-tab-current) {
     .chrome-tab-bg {
+      background: #dadada;
+    }
+
+    .chrome-tab-close {
+      background: #dadada;
+    }
+
+    .chrome-tab-title:after {
       background: #dadada;
     }
   }


### PR DESCRIPTION
ref: #933 #1304

This PR adds a View > Full Screen menu item. On MacOS the shortcut is <kbd>^</kbd>+<kbd>⌘</kbd>+<kbd>F</kbd> and on Win/Lunix it's <kbd>F11</kbd>. I needed to add some CSS tweaks for the tab appearance.

This PR doesn't deal with hiding/showing the toolbar in full screen mode. @pfrazee happy to look at setting that up in this PR or a future one.