### PR TITLE
UPnP support

### DIFF
--- a/app/background-process.js
+++ b/app/background-process.js
@@ -14,6 +14,7 @@ import * as rpc from 'pauls-electron-rpc'
 import * as beakerBrowser from './background-process/browser'
 import * as adblocker from './background-process/adblocker'
 import * as analytics from './background-process/analytics'
+import * as portForwarder from './background-process/nat-port-forwarder'
 
 import * as windows from './background-process/ui/windows'
 import * as modals from './background-process/ui/modals'
@@ -79,6 +80,8 @@ app.on('ready', async function () {
   // start the daemon process
   var datDaemonProcess = await childProcesses.spawn('dat-daemon', './dat-daemon.js')
 
+  portForwarder.setup()
+
   // setup core
   await beakerCore.setup({
     // paths
@@ -128,6 +131,7 @@ app.on('ready', async function () {
 })
 
 app.on('quit', () => {
+  portForwarder.closePort()
   childProcesses.closeAll()
 })
 

--- a/app/background-process/nat-port-forwarder.js
+++ b/app/background-process/nat-port-forwarder.js
@@ -1,0 +1,42 @@
+import * as beakerCore from '@beaker/core'
+//import { app } from 'electron'
+import ms from 'ms'
+import natUpnp from 'nat-upnp'
+import {DAT_SWARM_PORT} from '@beaker/core/lib/const'
+
+// exported methods
+// =
+
+export function setup () {
+  setTimeout(openPort, ms('3s'))
+}
+
+export function closePort () {
+  var client = natUpnp.createClient()
+  client.portUnmapping({public: DAT_SWARM_PORT})
+}
+
+// internal methods
+// =
+
+async function openPort () {
+  var opts = {
+    public: DAT_SWARM_PORT,
+    private: DAT_SWARM_PORT,
+    ttl: 1800  // 30 min
+  }
+
+  var client = natUpnp.createClient()
+  client.portMapping(opts, async (err) => {
+    if (!err) {
+      // schedule reopening the port every 30 minutes
+      var to = setTimeout(openPort, ms('30m'))
+      to.unref()
+    } else {
+      console.log(err)
+      // assuming errorCode 725 OnlyPermanentLeasesSupported and retry without a TTL
+      opts.ttl = '0'  // string not int
+      client.portMapping(opts)
+    }
+  })
+}

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "gulp-util": "^3.0.6",
     "gulp-watch": "^4.3.5",
     "into-stream": "^2.0.1",
+    "nat-upnp": "^1.1.1",
     "pre-commit": "^1.2.2",
     "q": "^1.4.1",
     "rollup": "^0.41.0",


### PR DESCRIPTION
This is a partial fix for #1246. This will only work for one  device behind the same NAT as all clients wants to  control the same port rather than using normal random port assignment. This would have to retry and negotiate with the router in addition to tracking which port that should be announced to the tracker.

I implemented this in Beaker rather than Dat as this required the least amount of change and will work as a temporary solution while we wait for Hyperswarm. This commit should be reverted when Hyperswarm is done.

I’ve evaluated all the UPnP NPM modules I could find and none of them are all that great. They silently don’t handle errors and don’t negotiate IGDv1/v2 properly. There are two common ways for port forwarding (permanent and ttl-leased) usually depending on the available memory on the router. I’ve tested it on two different consumer routers., but I believe this implementation should work for both permanent and ttl-leased port assignments for one device behind most edge routers. 