### PR TITLE
Replace ambiguous heart donation icons

### DIFF
--- a/app/builtin-pages/views/library-view.js
+++ b/app/builtin-pages/views/library-view.js
@@ -1026,7 +1026,7 @@ function renderSettingsView () {
               ? yo`
                   <p>
                     Enter a link to your donation page and Beaker will show
-                    a <span class="fa fa-heart"></span> icon in your page's URL bar.
+                    a <span class="fa fa-donate"></span> icon in your page's URL bar.
 
                     ${renderSettingsField({key: 'paymentLink', value: paymentLink, placeholder: 'Example: https://opencollective.com/beaker', onUpdate: setManifestValue})}
                   </p>
@@ -1169,7 +1169,7 @@ function renderNetworkView () {
                       </div>`
                   ] : yo`
                     <div class="hint">
-                      <i class="far fa-heart"></i>
+                      <i class="fa fa-hand-holding-heart"></i>
                       <strong>Give back!</strong> Seed this project${"'"}s files to help keep them online.
                       <a href="https://beakerbrowser.com/docs/how-beaker-works/peer-to-peer-websites#keeping-a-peer-to-peer-website-online" target="_blank" class="learn-more-link">Learn more</a>
                     </div>`

--- a/app/new-shell-window/navbar/location.js
+++ b/app/new-shell-window/navbar/location.js
@@ -225,7 +225,7 @@ class NavbarLocation extends LitElement {
     var cls = classMap({donate: true, pressed: this.isDonateMenuOpen})
     return html`
       <button class="${cls}" @click=${this.onClickDonateMenu}>
-        <i class="far fa-heart"></i>
+        <i class="fa fa-donate"></i>
       </button>
     `
   }

--- a/app/shell-menus/browser.js
+++ b/app/shell-menus/browser.js
@@ -167,7 +167,7 @@ class BrowserMenu extends LitElement {
           </div>
 
           <div class="menu-item" @click=${e => this.onOpenPage(e, 'https://opencollective.com/beaker')}>
-            <i class="far fa-heart"></i>
+            <i class="fa fa-donate"></i>
             <span class="label">Support Beaker</span>
           </div>
         </div>

--- a/app/shell-menus/donate.js
+++ b/app/shell-menus/donate.js
@@ -51,7 +51,7 @@ class DonateMenu extends LitElement {
       <div class="wrapper">
         <div class="header">
           <div class="header-info">
-            <span class="far fa-heart"></span>
+            <span class="fa fa-hand-holding-usd"></span>
             <h1>Contribute to ${title}</h1>
           </div>
         </div>

--- a/app/shell-window/ui/navbar/browser-menu.js
+++ b/app/shell-window/ui/navbar/browser-menu.js
@@ -198,7 +198,7 @@ export class BrowserMenuNavbarBtn {
                 </div>
 
                 <div class="menu-item" onclick=${e => this.onOpenPage(e, 'https://opencollective.com/beaker')}>
-                  <i class="far fa-heart"></i>
+                  <i class="fa fa-donate"></i>
                   <span class="label">Support Beaker</span>
                 </div>
               </div>

--- a/app/shell-window/ui/navbar/donate-menu.js
+++ b/app/shell-window/ui/navbar/donate-menu.js
@@ -30,7 +30,7 @@ export class DonateMenuNavbarBtn {
     return yo`
       <div class="donate-navbar-menu">
         <button class="nav-donate-btn" title="Donate to this site" onclick=${e => this.onClickBtn(e)}>
-          <i class="far fa-heart"></i>
+          <i class="fa fa-donate"></i>
         </button>
         ${dropdownEl}
       </div>
@@ -51,7 +51,7 @@ export class DonateMenuNavbarBtn {
         <div class="dropdown-items datsite-menu-dropdown-items donate-menu-dropdown-items with-triangle">
           <div class="header">
             <div class="header-info">
-              <span class="far fa-heart"></span>
+              <span class="fa fa-donate"></span>
               <h1>
                 Contribute to
                 ${page.siteInfo.title && page.siteInfo.title.length


### PR DESCRIPTION
Browsers have used hearts and stars to mean bookmarks interchangeably over the years; and still do to this day. Change the icon to avoid confusion with the bookmarking functionality and make it clearer what the button does.
dat://e71784fbaaac13e7a1b20ba39d8149b2ba893171204672575eab8b4fd0758ec3/1387/image.png

Icon changes (all were [fa-hearts](https://fontawesome.com/icons/heart?style=solid) previously):
* [fa-donate](https://fontawesome.com/icons/donate?style=solid) in location bar
* [fa-donate](https://fontawesome.com/icons/donate?style=solid) in Library: Archive: Settings
* [fa-donate](https://fontawesome.com/icons/donate?style=solid) in hamburger menu (donate to Beaker)
* [fa-hand-holding-usd](https://fontawesome.com/icons/hand-holding-usd?style=solid) in donation pop-out window
* [fa-hand-holding-heart](https://fontawesome.com/icons/hand-holding-heart?style=solid) (bandwidth) in Library: Archive: Network