### PR TITLE
Nudge people towards the forum when filing bugs

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,2 +1,10 @@
+<!--
+  Please only use the issue tracker to report bugs.
+  Use the forums to ask for help or discuss Beaker
+  and the distributed web.
+  https://dat.discourse.group/c/beaker
+-->
+
 Operation System:
+
 Beaker version:


### PR DESCRIPTION
The [Dat forum](https://dat.discourse.group/) is open for registration and can help keep support requests and discussions out of the bug tracker. It also provides better search and forum tools.