### PR TITLE
Fix typo in styles.css

### DIFF
--- a/app/assets/templates/website/styles.css
+++ b/app/assets/templates/website/styles.css
@@ -1,5 +1,5 @@
 /*
- * Want to change this website's styes? Learn more about CSS:
+ * Want to change this website's styles? Learn more about CSS:
  * https://developer.mozilla.org/en-US/docs/Learn/CSS/Introduction_to_CSS
  */
 


### PR DESCRIPTION
Just fixing a tiny typo in the `styles.css` template. 🙂 