### PR TITLE
feature: enable adblocker using @cliqz/adblocker-electron

### DIFF
--- a/app/background-process/adblocker.js
+++ b/app/background-process/adblocker.js
@@ -1,24 +1,30 @@
 import { session } from 'electron'
-// import { initialize, containsAds } from 'contains-ads'
+import { ElectronBlocker } from '@cliqz/adblocker-electron'
+import fetch from 'node-fetch'
 
 // exported API
 
 export function setup () {
-  /*
-  temporarily disabled due to https://github.com/bbondy/bloom-filter-cpp/issues/7
-    "contains-ads": "^0.2.5",
-
-  initialize() // contains-ads
-
-  const beakerUrls = /^(beaker|blob)/
-  session.defaultSession.webRequest.onBeforeRequest(['*://*./*'], (details, callback) => {
-    const shouldBeBlocked = !details.url.match(beakerUrls) && containsAds(details.url)
-
-    if (shouldBeBlocked) {
-      callback({cancel: true})
-    } else {
-      callback({cancel: false})
-    }
+  // Initializes an adblocker engine targeted at ads only (for extra tracking
+  // protection, `ElectronBlocker.fromPrebuiltAdsAndTracking(fetch)` can be
+  // used instead). The following lists are used with this preset:
+  //
+  // - Easylist: https://easylist.to/easylist/easylist.txt
+  // - Peter Lowe adservers list: https://pgl.yoyo.org/adservers/
+  // - uBlock Origin (resource abuse): https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/resource-abuse.txt
+  // - uBlock Origin (filters): https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/badware.txt
+  // - uBlock Origin (unbreak): https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/unbreak.txt
+  //
+  // Currently the resources are downloaded (less than 2 MB of data) every time
+  // Beaker starts, but could be cached locally in the future.
+  ElectronBlocker.fromPrebuiltAdsOnly(fetch).then((blocker) => {
+    // Calling this function will perform the following actions in order to
+    // enable adblocking in Beaker:
+    //
+    // - register listener to `webRequest.onHeadersReceived`
+    // - register listener to `webRequest.onBeforeRequest`
+    // - register a content script with `setPreloads` which allows to block
+    //   some extra ads which cannot be blocked by network filtering alone
+    blocker.enableBlockingInSession(session.defaultSession)
   })
-  */
 }

--- a/app/package.json
+++ b/app/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "@beaker/core": "beakerbrowser/beaker-core#electron5",
     "@beaker/dat-archive-file-diff": "^1.0.0",
+    "@cliqz/adblocker-electron": "^0.13.2",
     "anymatch": "^1.3.2",
     "await-lock": "^1.1.3",
     "beaker-error-constants": "^1.4.0",
@@ -65,6 +66,7 @@
     "multicb": "^1.2.2",
     "nan": "2.12.1",
     "nat-upnp": "^1.1.1",
+    "node-fetch": "^2.6.0",
     "normalize-url": "^1.9.1",
     "once": "^1.4.0",
     "os-name": "^2.0.1",


### PR DESCRIPTION
Hi there,

As a follow-up to this tweet: https://twitter.com/cblgh/status/1163102926707089408 I thought it would be interesting to see if adblocking can be enabled in Beaker again using [@cliqz/adblocker-electron](https://www.npmjs.com/package/@cliqz/adblocker-electron). I have put together a small proof-of-concept and it seems to work fine locally.

The way it currently works is this:

1. When `adblocker.setup()` is called, the resources for the adblocker are fetched (<2 MB of rules used to block ads: easylist, etc.) and an instance of `ElectronBlocker` is created.
2. Blocking is enabled in `session.defaultSession` by registering listeners to `webRequest.onHeadersReceived` and `webRequest.onBeforeRequest`, as well as registering a preload script which allows to further hide and block ads which cannot be removed via network filtering alone.

Optionally, the instance of `ElectronBlocker` can be serialized (to a typed array `Uint8Array`) and persisted on disk for faster retrieval. This can be done from `adblocker.js` or from a `postinstall` script which would create this file at build-time instead of runtime (none of this is implemented in the pull request yet).

Last but not least, currently the setup is only targeted at blocking ads, but not tracking. This means that filters such as `easyprivacy` are not enabled. The result is, less resources are needed to perform blocking, and there should be less breakage in practice (although this is usually very small even when anti-tracking rules are enabled).

Let me know what you think about it, happy to make some changes if you would like to move forward with this.

Best,
Rémi