### PR TITLE
package.json: Upgrade appdmg to fix fs-xattr version for node 12.0+

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "yargs": "^4.2.0"
   },
   "optionalDependencies": {
-    "appdmg": "^0.4.5",
+    "appdmg": "^0.6.0",
     "rcedit": "^0.5.0"
   },
   "build": {


### PR DESCRIPTION
package.json: Upgrade appdmg to fix fs-xattr version for node 12.0+

appdmg 0.4.5 depends on fs-xattr 0.1.17 which doesn't compile on node 12 or higher.
Updating to appdmg 0.6.0 fixes the fs-xattr dep to 0.3.0 which does compile.

This drops support for node < 8.5.x which hopefully isn't a problem.

See https://github.com/LinusU/node-appdmg/issues/176



Example of compiling with the outdated version:
```

> fs-xattr@0.1.17 install /Users/erg/beaker/node_modules/fs-xattr
> node-gyp rebuild

  CXX(target) Release/obj.target/xattr/src/async.o
../src/async.cc:35:15: warning: 'Call' is deprecated [-Wdeprecated-declarations]
    callback->Call(1, argv);
              ^
../../nan/nan.h:1739:3: note: 'Call' has been explicitly marked deprecated here
  NAN_DEPRECATED inline v8::Local<v8::Value>
  ^
../../nan/nan.h:104:40: note: expanded from macro 'NAN_DEPRECATED'
# define NAN_DEPRECATED __attribute__((deprecated))
                                       ^
../src/async.cc:52:46: error: no matching member function for call to 'ToObject'
    v8::Local<v8::Object> bufferObj = value->ToObject();
                                      ~~~~~~~^~~~~~~~
/Users/erg/.node-gyp/12.0.0/include/node/v8.h:2532:44: note: candidate function not viable: requires single argument 'context', but no arguments were provided
  V8_WARN_UNUSED_RESULT MaybeLocal<Object> ToObject(
                                           ^
/Users/erg/.node-gyp/12.0.0/include/node/v8.h:2546:35: note: candidate function not viable: requires single argument 'isolate', but no arguments were provided
                    Local<Object> ToObject(Isolate* isolate) const);
                                  ^
../src/async.cc:129:15: warning: 'Call' is deprecated [-Wdeprecated-declarations]
    callback->Call(2, argv);
              ^
../../nan/nan.h:1739:3: note: 'Call' has been explicitly marked deprecated here
  NAN_DEPRECATED inline v8::Local<v8::Value>
  ^
../../nan/nan.h:104:40: note: expanded from macro 'NAN_DEPRECATED'
# define NAN_DEPRECATED __attribute__((deprecated))
                                       ^
../src/async.cc:186:15: warning: 'Call' is deprecated [-Wdeprecated-declarations]
    callback->Call(2, argv);
              ^
../../nan/nan.h:1739:3: note: 'Call' has been explicitly marked deprecated here
  NAN_DEPRECATED inline v8::Local<v8::Value>
  ^
../../nan/nan.h:104:40: note: expanded from macro 'NAN_DEPRECATED'
# define NAN_DEPRECATED __attribute__((deprecated))
                                       ^
3 warnings and 1 error generated.
make: *** [Release/obj.target/xattr/src/async.o] Error 1
gyp ERR! build error
gyp ERR! stack Error: `make` failed with exit code: 2
gyp ERR! stack     at ChildProcess.onExit (/Users/erg/.nvm/versions/node/v12.0.0/lib/node_modules/npm/node_modules/node-gyp/lib/build.js:262:23)
gyp ERR! stack     at ChildProcess.emit (events.js:196:13)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:256:12)
gyp ERR! System Darwin 19.2.0
gyp ERR! command "/Users/erg/.nvm/versions/node/v12.0.0/bin/node" "/Users/erg/.nvm/versions/node/v12.0.0/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
gyp ERR! cwd /Users/erg/beaker/node_modules/fs-xattr
gyp ERR! node -v v12.0.0
gyp ERR! node-gyp -v v3.8.0
gyp ERR! not ok

> beakerbrowser@ postinstall /Users/erg/beaker
> cd app && npm install

npm WARN beakerbrowser@ No license field.
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: fs-xattr@0.1.17 (node_modules/fs-xattr):
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: fs-xattr@0.1.17 install: `node-gyp rebuild`
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: Exit status 1
```