### PR TITLE
change previous/next tab keyboard shortcut on macOS

### DIFF
--- a/app/bg/ui/window-menu.js
+++ b/app/bg/ui/window-menu.js
@@ -533,7 +533,7 @@ export function buildWindowMenu (opts = {}) {
       {
         label: 'Next Tab',
         enabled: !noWindows,
-        accelerator: 'CmdOrCtrl+PageDown',
+        accelerator: (process.platform === 'darwin') ? 'Alt+CmdOrCtrl+Right' : 'CmdOrCtrl+PageDown',
         click: function (item) {
           var win = getWin()
           if (win) tabManager.changeActiveBy(win, 1)
@@ -542,7 +542,7 @@ export function buildWindowMenu (opts = {}) {
       {
         label: 'Previous Tab',
         enabled: !noWindows,
-        accelerator: 'CmdOrCtrl+PageUp',
+        accelerator: (process.platform === 'darwin') ? 'Alt+CmdOrCtrl+Left' : 'CmdOrCtrl+PageUp',
         click: function (item) {
           var win = getWin()
           if (win) tabManager.changeActiveBy(win, -1)


### PR DESCRIPTION
I've had this PR in mind for a while and finally decided to go ahead and implement it!

On [Chrome](https://support.google.com/chrome/answer/157179?hl=en), [Firefox](https://support.mozilla.org/en-US/kb/keyboard-shortcuts-perform-firefox-tasks-quickly#w_windows-tabs) and [Brave](https://support.brave.com/hc/en-us/articles/360032272171-What-keyboard-shortcuts-can-I-use-in-Brave-) on macOS, one of the keyboard shortcuts I use the most is ⌘ + Option + Right arrow (jump to the next open tab) and ⌘ + Option + Left arrow (jump to the previous open tab).

On Windows and Linux, the equivalent shortcut is Ctrl + PgDn or Ctrl + PgUp. This is also the shortcut currently used in Beaker on Windows and Linux. But on macOS, it's currently ⌘ + PgDn and ⌘ + PgUp. I'm not aware of any browsers on macOS that support ⌘ + PgDn and ⌘ + PgUp (instead they support Ctrl + PgDn and Ctrl + PgUp). The main shortcut that most browsers on macOS (other than Safari) seem to recommend is ⌘ + Option + Right arrow and ⌘ + Option + Left arrow. So I think it could make sense to change it to that for now. Let me know what you think 🙂