### PR TITLE
Add hyperdrive "capability" URLs

### DIFF
--- a/app/bg/hyper/capabilities.js
+++ b/app/bg/hyper/capabilities.js
@@ -1,0 +1,111 @@
+import * as base32 from 'base32.js'
+import * as crypto from 'crypto'
+import { PermissionsError } from 'beaker-error-constants'
+import { parseDriveUrl } from '../../lib/urls'
+
+// typedefs
+// =
+
+/**
+ * @typedef {Object} CapabilityMapping
+ * @prop {String} owningOrigin
+ * @prop {String} token
+ * @prop {Object} target
+ * @prop {String} target.key
+ * @prop {String} target.version
+ */
+
+// globals
+// =
+
+/** @type CapabilityMapping[] */
+var capabilities = []
+
+// exported api
+// =
+
+/**
+ * @param {string} capUrl 
+ * @returns {CapabilityMapping}
+ */
+export function lookupCap (capUrl) {
+  var token = extractToken(capUrl)
+  if (!token) throw new Error('Invalid capability URL')
+  return capabilities.find(c => c.token === token)
+}
+
+/**
+ * @param {String} origin
+ * @param {String} target
+ * @returns {String}
+ */
+export function createCap (origin, target) {
+  var token = generateToken()
+  capabilities.push({
+    owningOrigin: origin,
+    token,
+    target: parseTarget(target)
+  })
+  return `hyper://${token}.cap/`
+}
+
+/**
+ * @param {String} origin
+ * @param {String} capUrl
+ * @param {String} target
+ * @returns {Void}
+ */
+export function modifyCap (origin, capUrl, target) {
+  var token = extractToken(capUrl)
+  if (!token) throw new Error('Invalid capability URL')
+  var cap = capabilities.find(c => c.token === token)
+  if (!cap) throw new Error('Capability does not exist')
+  
+  if (cap.owningOrigin !== origin) {
+    throw new PermissionsError('Cannot modify unowned capability')
+  }
+
+  cap.target = parseTarget(target)
+}
+
+/**
+ * @param {String} origin
+ * @param {String} capUrl
+ * @returns {Void}
+ */
+export function deleteCap (origin, capUrl) {
+  var token = extractToken(capUrl)
+  if (!token) throw new Error('Invalid capability URL')
+  var capIndex = capabilities.findIndex(c => c.token === token)
+  if (capIndex === -1) throw new Error('Capability does not exist')
+  
+  if (capabilities[capIndex].owningOrigin !== origin) {
+    throw new PermissionsError('Cannot modify unowned capability')
+  }
+  
+  capabilities.splice(capIndex, 1)
+}
+
+// internal methods
+// =
+
+function generateToken () {
+  var buf = crypto.randomBytes(8)
+  var encoder = new base32.Encoder({type: 'rfc4648', lc: true})
+  return encoder.write(buf).finalize()
+}
+
+function extractToken (capUrl) {
+  var matches = /^(hyper:\/\/)?([a-z0-9]+)\.cap\/?/.exec(capUrl)
+  return matches ? matches[2] : undefined
+}
+
+function parseTarget (target) {
+  try {
+    var urlp = parseDriveUrl(target)
+    if (urlp.protocol !== 'hyper:') throw new Error()
+    return {key: urlp.hostname, version: urlp.version}
+  } catch (e) {
+    throw new Error('Invalid target hyper:// URL')
+  }
+}

--- a/app/bg/hyper/dns.js
+++ b/app/bg/hyper/dns.js
@@ -3,6 +3,7 @@ import datDnsFactory from 'dat-dns'
 import * as datDnsDb from '../dbs/dat-dns'
 import * as drives from './drives'
 import { HYPERDRIVE_HASH_REGEX } from '../../lib/const'
+import * as capabilities from './capabilities'
 import * as logLib from '../logger'
 const logger = logLib.child({category: 'hyper', subcategory: 'dns'})
 

--- a/app/bg/web-apis/bg.js
+++ b/app/bg/web-apis/bg.js
@@ -41,12 +41,14 @@ import { WEBAPI as downloadsAPI } from '../ui/downloads'
 import { WEBAPI as beakerBrowserAPI } from '../browser'
 
 // external manifests
+import capabilitiesManifest from './manifests/external/capabilities'
 import contactsManifest from './manifests/external/contacts'
 import hyperdriveManifest from './manifests/external/hyperdrive'
 import peersocketsManifest from './manifests/external/peersockets'
 import shellManifest from './manifests/external/shell'
 
 // external apis
+import capabilitiesAPI from './bg/capabilities'
 import contactsAPI from './bg/contacts'
 import hyperdriveAPI from './bg/hyperdrive'
 import peersocketsAPI from './bg/peersockets'
@@ -78,6 +80,7 @@ export const setup = function () {
   rpc.exportAPI('watchlist', watchlistManifest, watchlistAPI, internalOnly)
 
   // external apis
+  rpc.exportAPI('capabilities', capabilitiesManifest, capabilitiesAPI, secureOnly('capabilities'))
   rpc.exportAPI('contacts', contactsManifest, contactsAPI, secureOnly('contacts'))
   rpc.exportAPI('hyperdrive', hyperdriveManifest, hyperdriveAPI, secureOnly('hyperdrive'))
   rpc.exportAPI('peersockets', peersocketsManifest, peersocketsAPI, secureOnly('peersockets'))

--- a/app/bg/web-apis/bg/capabilities.js
+++ b/app/bg/web-apis/bg/capabilities.js
@@ -1,0 +1,35 @@
+import { parseDriveUrl } from '../../../lib/urls'
+import * as capabilities from '../../hyper/capabilities'
+
+// exported api
+// =
+
+export default {
+  /**
+   * @param {String} target
+   * @returns {Promise<String>}
+   */
+  async create (target) {
+    var origin = parseDriveUrl(this.sender.getURL()).origin
+    return capabilities.createCap(origin, target)
+  },
+
+  /**
+   * @param {String} capUrl
+   * @param {String} target
+   * @returns {Promise<Void>}
+   */
+  async modify (capUrl, target) {
+    var origin = parseDriveUrl(this.sender.getURL()).origin    
+    return capabilities.modifyCap(origin, capUrl, target)
+  },
+
+  /**
+   * @param {String} capUrl
+   * @returns {Promise<Void>}
+   */
+  async delete (capUrl) {
+    var origin = parseDriveUrl(this.sender.getURL()).origin    
+    return capabilities.deleteCap(origin, capUrl)
+  }
+}

--- a/app/bg/web-apis/fg/external.js
+++ b/app/bg/web-apis/fg/external.js
@@ -1,5 +1,6 @@
 import { fromEventStream } from './event-target'
 import errors from 'beaker-error-constants'
+import capabilitiesManifest from '../manifests/external/capabilities'
 import contactsManifest from '../manifests/external/contacts'
 import peersocketsManifest from '../manifests/external/peersockets'
 import shellManifest from '../manifests/external/shell'
@@ -7,8 +8,9 @@ import shellManifest from '../manifests/external/shell'
 const RPC_OPTS = { timeout: false, errors }
 
 export const setup = function (rpc) {
-  var shell = rpc.importAPI('shell', shellManifest, RPC_OPTS)
+  var capabilities = rpc.importAPI('capabilities', capabilitiesManifest, RPC_OPTS)
   var contacts = rpc.importAPI('contacts', contactsManifest, RPC_OPTS)
+  var shell = rpc.importAPI('shell', shellManifest, RPC_OPTS)
 
   var peersocketsRPC = rpc.importAPI('peersockets', peersocketsManifest, RPC_OPTS)
   var peersockets = {
@@ -52,5 +54,5 @@ export const setup = function (rpc) {
     }
   }
 
-  return {contacts, peersockets, shell, terminal}
+  return {capabilities, contacts, peersockets, shell, terminal}
 }

--- a/app/bg/web-apis/manifests/external/capabilities.js
+++ b/app/bg/web-apis/manifests/external/capabilities.js
@@ -1,0 +1,5 @@
+export default {
+  create: 'promise',
+  modify: 'promise',
+  delete: 'promise'
+}

--- a/app/package.json
+++ b/app/package.json
@@ -18,6 +18,7 @@
     "ajv": "^6.10.2",
     "anymatch": "^2.0.0",
     "await-lock": "^1.2.1",
+    "base32.js": "^0.1.0",
     "beaker-error-constants": "^1.4.0",
     "beaker-virtual-fs": "git://github.com/beakerbrowser/beaker-virtual-fs.git#a4b3112df5328e99e63e1786823b3705ab031c77",
     "binary-extensions": "^1.13.1",


### PR DESCRIPTION
Doing this one as a PR for documentation. (Sorry for the malformed initial PR; I fat-fingered it.)

This PR adds a "capability URL" and Web API. These are capabilities in the [capabilities security model](https://en.wikipedia.org/wiki/Capability-based_security) sense. They are opaque URLs which map to hyperdrives while hiding the URL.

The hyperdrive capability URL uses a special `.cap` pseudo-TLD. They are formed as `hyper://{random-base32-id}.cap/`. I decided to use a pseudo-TLD instead of a new URL scheme so that the URL scheme does not change from other hyperdrives.

The purpose of capability URLs is to provide security primitives for constrained access to a hyperdrive. The default security model of a hyperdrive is that the pubkey provides read access locally and over the network. Because the pubkey is unchangeable, it's impossible to revoke access to a pubkey once it's acquired. These "capability URLs" are local mappings from random IDs to the hyperdrive pubkeys, and therefore can provide read access without giving away the pubkey.

Use-cases:

 - The `beaker.shell` methods include "select file" and "select drive" modals which provide the URL to the selected items. By returning a capability URL, these modals can provide temporary access to the selected items.
 - Applications can share capability URLs with other applications (e.g. in an iframe) to provide temporary and constrained access.
 - (A secondary usecase) Applications can remap capability URLs after providing them to some component, thereby changing the mapping without changing the URL.

In this iteration, the capability URLs are local and stored in-memory. They will be "destroyed" when the browser restarts. They are not networked and therefore cannot be shared with other users. They are able to map to a key and a drive-version, but cannot map to subfolders or files. They do not currently constrain the available operations. All of these properties can be changed over time as we need; it's easy to see how subresource mapping and operation-constraints could be beneficial.

The web API is as follows:

```js
var capUrl = await beaker.capabilities.create(target)
await beaker.capabilities.modify(capUrl, target)
await beaker.capabilities.delete(capUrl)
```

The origin which creates a capability is marked as the "owner" and is the only origin which can modify or delete a capability after its creation.