### PR TITLE
Minor change

### DIFF
--- a/app/userland/editor/js/main.js
+++ b/app/userland/editor/js/main.js
@@ -395,7 +395,7 @@ class EditorApp extends LitElement {
       })
       items.push({type: 'separator'})
       items.push({
-        label: 'Export file',
+        label: 'Export',
         click: () => this.onClickExportFiles([item.url])
       })
     } else {
@@ -600,7 +600,7 @@ class EditorApp extends LitElement {
         '-',
         {
           icon: 'fas fa-fw fa-file-export',
-          label: 'Export file',
+          label: 'Export',
           disabled: this.dne,
           click: () => this.onClickExportFiles(this.resolvedPath)
         }


### PR DESCRIPTION
Considering that this context menu also shows up when you right-click on a folder, I think it could make sense to rename it to Export. This is also how it's called in the Files Explorer. I also renamed it to Export for the actions menu just to be consistent but could also make sense to leave it like that.