### PR TITLE
Clean up issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,30 +7,30 @@ assignees: ''
 
 ---
 
-<!-- if you have a general question, use the discussions at https://github.com/beakerbrowser/beaker/discussions instead -->
+<!-- If you have a general question, use the discussions at https://github.com/beakerbrowser/beaker/discussions instead. -->
 
 <!-- NOTE -- Please don't open issues which might indicate that laws (such as copyright) might be broken in your use of our software. While you may be operating within your legal rights with the content, it's hard for us to know at a glance, and so for simplicity it's best to steer clear of legal issues such as copyrighted material. -->
 
-**Describe the bug**
-A clear and concise description of what the bug is.
+**Describe the Bug**
+<!-- A clear and concise description of what the bug is. -->
 
 **To Reproduce**
-Steps to reproduce the behavior:
+<!-- Steps to reproduce the behavior:
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
 4. See error
+-->
 
-**Expected behavior**
-A clear and concise description of what you expected to happen.
+**Expected Behavior**
+<!-- A clear and concise description of what you expected to happen. -->
 
 **Screenshots**
-If applicable, add screenshots to help explain your problem.
+<!-- If applicable, add screenshots to help explain your problem. -->
 
-**Desktop (please complete the following information):**
- - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
+**Environment**
+ - OS: <!-- e.g. Windows 10 -->
+ - Beaker Version: <!-- e.g. 1.0.0-prerelease.3 -->
 
-**Additional context**
-Add any other context about the problem here.
+**Additional Context**
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,18 +7,18 @@ assignees: ''
 
 ---
 
-<!-- if you have a general question, use the discussions at https://github.com/beakerbrowser/beaker/discussions instead -->
+<!-- If you have a general question, use the discussions at https://github.com/beakerbrowser/beaker/discussions instead. -->
 
 <!-- NOTE -- Please don't open issues which might indicate that laws (such as copyright) might be broken in your use of our software. While you may be operating within your legal rights with the content, it's hard for us to know at a glance, and so for simplicity it's best to steer clear of legal issues such as copyrighted material. -->
 
-**Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+**Is Your Feature Request Related to a Problem? Please Describe**
+<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
 
-**Describe the solution you'd like**
-A clear and concise description of what you want to happen.
+**Solution You'd Like**
+<!-- A clear and concise description of what you want to happen. -->
 
-**Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
+**Alternatives You've Considered**
+<!-- A clear and concise description of any alternative solutions or features you've considered. -->
 
-**Additional context**
-Add any other context or screenshots about the feature request here.
+**Additional Context**
+<!-- Add any other context or screenshots about the feature request here. -->


### PR DESCRIPTION
- Adjust field titles.
- Remove unneeded "Browser" field under "Desktop".
- Convert field descriptions to comments to ensure that users don't submit them when skipping a section.