### PR TITLE
added 'Save Link As' functionality to context menu on right clicking URL 

### DIFF
--- a/app/bg/ui/context-menu.js
+++ b/app/bg/ui/context-menu.js
@@ -56,6 +56,7 @@ export default function registerContextMenu () {
       // links
       if (props.linkURL) {
         menuItems.push({ label: 'Open Link in New Tab', click: (item, win) => tabManager.create(win, props.linkURL, {setActive: true, adjacentActive: true}) })
+        menuItems.push({ label: 'Save Link As...', click: downloadPrompt('linkURL','.html')})
         menuItems.push({ label: 'Copy Link Address', click: () => clipboard.writeText(props.linkURL) })
         menuItems.push({ type: 'separator' })
       }


### PR DESCRIPTION
Fixes #1619 . First pull request ever on an open source, please let me know if I should be doing anything differently. Right click on url now displays "Save Link As" functionality. If there is no file extension, defaults to html.
