### PR TITLE
about URI's accepted as valid as opposed to triggering search

### DIFF
--- a/app/lib/urls.js
+++ b/app/lib/urls.js
@@ -17,11 +17,12 @@ export function examineLocationInput (v) {
     v.includes('://') ||
     v.startsWith('beaker:') ||
     v.startsWith('data:') ||
-    v.startsWith('intent:')
+    v.startsWith('intent:') ||
+    v.startsWith('about:')
   ))
   var vWithProtocol = v
   var isGuessingTheScheme = false
-  if (isProbablyUrl && !isPath.test(v) && !v.includes('://') && !(v.startsWith('beaker:') || v.startsWith('data:') || v.startsWith('intent:'))) {
+  if (isProbablyUrl && !isPath.test(v) && !v.includes('://') && !(v.startsWith('beaker:') || v.startsWith('data:') || v.startsWith('intent:') || v.startsWith('about:'))) {
     if (isDatHashRegex.test(v)) {
       vWithProtocol = 'hyper://' + v
     } else if (v.startsWith('localhost') || isIPAddressRegex.test(v)) {


### PR DESCRIPTION
fixes issue #1669. Another massive pull request! `about:blank` redirects correctly, but all other required `about:` uri's redirect to `about:blank#blocked`. I am not sure if that is chromium issue or how important it is, however, this is a step in the right direction.