### PR TITLE
added missing s to searchEngine

### DIFF
--- a/app/bg/ui/context-menu.js
+++ b/app/bg/ui/context-menu.js
@@ -126,7 +126,7 @@ export default function registerContextMenu () {
           searchPreviewStr += '"'
         }
         var searchEngines = await settingsDb.get('search_engines')
-        var searchEngine = searchEngines.find(se => se.selected) || searchEngine[0]
+        var searchEngine = searchEngines.find(se => se.selected) || searchEngines[0]
         var query = searchEngine.url+ '?q=' + encodeURIComponent(props.selectionText.substr(0, 500)) // Limit query to prevent too long query error from DDG
         menuItems.push({ label: 'Search ' + searchEngine.name + ' for "' + searchPreviewStr, click: (item, win) => tabManager.create(win, query, {adjacentActive: true}) })
         menuItems.push({ type: 'separator' })


### PR DESCRIPTION
Super tiny typo in context-menu that throws error when no default search engine is selected. Is just a fallback and will probably never run, but you never know. 
