### PR TITLE
added launch at startup functionality

### DIFF
--- a/app/bg/dbs/settings.js
+++ b/app/bg/dbs/settings.js
@@ -41,6 +41,7 @@ export const setup = async function (opts) {
     new_tabs_in_foreground: 0,
     run_background: 1,
     default_zoom: 0,
+    launch_on_startup: 0,
     start_page_background_image: '',
     workspace_default_path: path.join(opts.homePath, 'Sites'),
     default_dat_ignore: '.git\n.dat\nnode_modules\n*.log\n**/.DS_Store\nThumbs.db\n',

--- a/app/bg/web-apis/manifests/internal/browser.js
+++ b/app/bg/web-apis/manifests/internal/browser.js
@@ -6,6 +6,7 @@ export default {
   getProfile: 'promise',
   checkForUpdates: 'promise',
   restartBrowser: 'sync',
+  setRunOnStartup: 'promise',
 
   getSettings: 'promise',
   getSetting: 'promise',
@@ -14,7 +15,7 @@ export default {
   setupDefaultProfile: 'promise',
   migrate08to09: 'promise',
   setStartPageBackgroundImage: 'promise',
-  
+
   getDefaultProtocolSettings: 'promise',
   setAsDefaultProtocolClient: 'promise',
   removeAsDefaultProtocolClient: 'promise',
@@ -34,7 +35,6 @@ export default {
 
   getResourceContentType: 'sync',
   getCertificate: 'promise',
-
   executeSidebarCommand: 'promise',
   executeShellWindowCommand: 'promise',
   toggleSiteInfo: 'promise',

--- a/app/package.json
+++ b/app/package.json
@@ -12,6 +12,7 @@
     "@beaker/library-tools": "^1.0.0",
     "ajv": "^6.10.2",
     "anymatch": "^2.0.0",
+    "auto-launch": "^5.0.5",
     "await-lock": "^1.2.1",
     "base32.js": "^0.1.0",
     "beaker-error-constants": "^1.4.0",

--- a/app/userland/settings/js/views/general.js
+++ b/app/userland/settings/js/views/general.js
@@ -262,23 +262,36 @@ class GeneralSettingsView extends LitElement {
   renderRunBackgroundSettings () {
     return html`
       <div class="section on-startup">
-        <h2 id="on-startup">Background</h2>
+        <h2 id="on-startup">Background & Startup</h2>
 
         <p>
           Running in the background helps keep your data online even if you're not using Beaker.
         </p>
-
-        <div class="radio-item">
-          <input type="checkbox" id="runBackground"
-                 ?checked=${this.settings.run_background == 1}
-                 @change=${this.onRunBackgroundToggle} />
-          <label for="runBackground">
-            Let Beaker run in the background
-          </label>
+        <div>
+          <div class="radio-item">
+            <input type="checkbox" id="runBackground"
+                   ?checked=${this.settings.run_background == 1}
+                   @change=${this.onRunBackgroundToggle} />
+            <label for="runBackground">
+              Let Beaker run in the background
+            </label>
+          </div>
+          <div>
+            <div class="radio-item">
+              <input type="checkbox" id="onStart"
+                     ?checked=${this.settings.launch_on_startup == 1}
+                     @change=${this.onLaunchOnStartupToggle} />
+              <label for=onStart">
+                Launch Beaker on computer startup
+              </label>
+            </div>
+          </div>
         </div>
       </div>
     `
   }
+
+
 
   renderNewTabSettings () {
     return html`
@@ -336,6 +349,8 @@ class GeneralSettingsView extends LitElement {
       </div>
     `
   }
+
+
 
   renderDefaultZoomSettings () {
     const opt = (v, label) => html`
@@ -492,6 +507,13 @@ class GeneralSettingsView extends LitElement {
   onRunBackgroundToggle (e) {
     this.settings.run_background = this.settings.run_background == 1 ? 0 : 1
     beaker.browser.setSetting('run_background', this.settings.run_background)
+    toast.create('Setting updated')
+  }
+
+  async onLaunchOnStartupToggle (e) {
+    const desiredState = e.target.checked
+    beaker.browser.setSetting('launch_on_startup', desiredState?1:0)
+    await beaker.browser.setRunOnStartup(desiredState)
     toast.create('Setting updated')
   }
 


### PR DESCRIPTION
Implements #1665 
Alright! So, this is not fully tested but:
 - works on mac
 - don't have a windows box to test, but I followed all the instructions to ensure it works with the auto-updater.
 - doesn't work when running from source (but I don't think you want it to?)
- linux works, but I cannot seem to find the correct executable path.  both process.execPath and app.getPath('exe') give you the file stored in /tmp/.mount_Beakerxxx which seems to have something to do with the builder? I did a bunch of searching, but cannot find the solution. I am sure it is straightforward and if it is easy, you just need to swap out process.execPath on line 889 of browser.js

If you need changes, just let me know!