### PR TITLE
Fixed overlapping UI in the history tab

### DIFF
--- a/app/userland/history/css/main.css.js
+++ b/app/userland/history/css/main.css.js
@@ -16,7 +16,7 @@ nav {
   position: fixed;
   top: 25px;
   left: 15px;
-  width: 200px;
+  width: 185px;
   z-index: 1;
 }
 
@@ -59,6 +59,12 @@ nav a.active .fas {
 main {
   max-width: 700px;
   margin: 20px auto;
+}
+
+@media screen and (max-width: 1115px) {
+  main {
+    margin-left: 200px;
+  }
 }
 
 .search-container {


### PR DESCRIPTION
I noticed that the browsing history tab had overlapping elements when opening DevTools or using split windows on my 1366x768 monitor. 

**Before:**
<img src="https://user-images.githubusercontent.com/47720873/87253829-871d7700-c47e-11ea-8fbe-ce7b2dddf8c7.png" width=500>

I fixed it by adding a media query which sets a left margin when reaching the breakpoint. I then adjusted the width of the navbar slightly to remove the remaining overlap.

**After:**
<img src="https://user-images.githubusercontent.com/47720873/87253827-8684e080-c47e-11ea-9d87-8eefdcdab38c.png" width=500>

