### PR TITLE
Improve mime type detection for hyper://

### DIFF
--- a/app/bg/protocols/hyper.js
+++ b/app/bg/protocols/hyper.js
@@ -370,7 +370,11 @@ export const protocolHandler = async function (request, respond) {
       })
     }
 
-    var mimeType = mime.identify(entry.path)
+    var chunk;
+    for await (const part of checkoutFS.session.drive.createReadStream(entry.path, { start: 0, length: 512 })) {
+      chunk = chunk ? Buffer.concat(chunk, part) : part;
+    }
+    var mimeType = mime.identify(entry.path, chunk)
     if (!canExecuteHTML && mimeType.includes('text/html')) {
       mimeType = 'text/plain'
     }

--- a/app/bg/protocols/hyper.js
+++ b/app/bg/protocols/hyper.js
@@ -370,11 +370,14 @@ export const protocolHandler = async function (request, respond) {
       })
     }
 
-    var chunk;
-    for await (const part of checkoutFS.session.drive.createReadStream(entry.path, { start: 0, length: 512 })) {
-      chunk = chunk ? Buffer.concat(chunk, part) : part;
+    var mimeType = entry.metadata.mimeType;
+    if (!mimeType) {
+      let chunk;
+      for await (const part of checkoutFS.session.drive.createReadStream(entry.path, { start: 0, length: 512 })) {
+        chunk = chunk ? Buffer.concat(chunk, part) : part;
+      }
+      mimeType = mime.identify(entry.path, chunk)
     }
-    var mimeType = mime.identify(entry.path, chunk)
     if (!canExecuteHTML && mimeType.includes('text/html')) {
       mimeType = 'text/plain'
     }


### PR DESCRIPTION
Currently the mime type is purely detected based on file name. This is a challenge if the file name does not include the actual file type.

Speaking with @mafintosh and @digli me together with @digli concluded that we could do two things:

1. Actually read a chunk and use that to detect mime type
2. Save the mime type to the metadata and use that explicit mime type rather than implicitly derive it from the file

This PR contains both approaches – one commit for each.