### PR TITLE
Implement ad blocking with filter list selection

### DIFF
--- a/app/bg/browser.js
+++ b/app/bg/browser.js
@@ -11,6 +11,7 @@ import EventEmitter from 'events'
 import LRU from 'lru'
 const exec = require('util').promisify(require('child_process').exec)
 import * as logLib from './logger'
+import * as adblocker from './adblocker'
 const logger = logLib.child({category: 'browser'})
 import * as settingsDb from './dbs/settings'
 import { convertDatArchive } from './dat/index'
@@ -146,6 +147,7 @@ export const WEBAPI = {
   getSetting,
   getSettings,
   setSetting,
+  updateAdblocker,
   updateSetupState,
   setupDefaultProfile,
   migrate08to09,
@@ -577,6 +579,10 @@ export function getSettings () {
 
 export function setSetting (key, value) {
   return settingsDb.set(key, value)
+}
+
+export function updateAdblocker () {
+  return adblocker.setup()
 }
 
 export async function migrate08to09 () {

--- a/app/bg/dbs/settings.js
+++ b/app/bg/dbs/settings.js
@@ -6,7 +6,7 @@ import { setupSqliteDB } from '../lib/db'
 import { getEnvVar } from '../lib/env'
 
 const CACHED_VALUES = ['new_tabs_in_foreground']
-const JSON_ENCODED_SETTINGS = ['search_engines']
+const JSON_ENCODED_SETTINGS = ['search_engines', 'adblock_lists']
 
 // globals
 // =
@@ -46,6 +46,14 @@ export const setup = async function (opts) {
     search_engines: [
       {name: 'DuckDuckGo', url: 'https://www.duckduckgo.com/', selected: true},
       {name: 'Google', url: 'https://www.google.com/search'}
+    ],
+    adblock_lists: [
+      {name: 'EasyList', url: 'https://easylist.to/easylist/easylist.txt', selected: true},
+      {name: 'EasyPrivacy', url: 'https://easylist.to/easylist/easyprivacy.txt'},
+      {name: 'EasyList Cookie List', url: 'https://easylist-downloads.adblockplus.org/easylist-cookie.txt'},
+      {name: 'Fanboy\'s Social Blocking List', url: 'https://easylist.to/easylist/fanboy-social.txt'},
+      {name: 'Fanboy\'s Annoyance List', url: 'https://easylist.to/easylist/fanboy-annoyance.txt'},
+      {name: 'Adblock Warning Removal List', url: 'https://easylist-downloads.adblockplus.org/antiadblockfilters.txt'},
     ]
   }
 

--- a/app/bg/web-apis/manifests/internal/browser.js
+++ b/app/bg/web-apis/manifests/internal/browser.js
@@ -10,6 +10,7 @@ export default {
   getSettings: 'promise',
   getSetting: 'promise',
   setSetting: 'promise',
+  updateAdblocker: 'promise',
   updateSetupState: 'promise',
   setupDefaultProfile: 'promise',
   migrate08to09: 'promise',

--- a/app/package.json
+++ b/app/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "@beaker/dat-serve-resolve-path": "^1.0.0",
     "@beaker/library-tools": "^1.0.0",
+    "@cliqz/adblocker": "^1.17.0",
     "ajv": "^6.10.2",
     "anymatch": "^2.0.0",
     "await-lock": "^1.2.1",
@@ -21,6 +22,7 @@
     "bytes": "^3.1.0",
     "circular-append-file": "^1.0.1",
     "concat-stream": "^1.6.2",
+    "cross-fetch": "^3.0.5",
     "dat-dns": "^3.2.1",
     "dat-encoding": "^5.0.1",
     "data-urls": "^1.0.0",

--- a/app/userland/settings/css/views/adblock.css.js
+++ b/app/userland/settings/css/views/adblock.css.js
@@ -1,0 +1,111 @@
+import {css} from '../../../app-stdlib/vendor/lit-element/lit-element.js'
+import colorsCSS from '../../../app-stdlib/css/colors.css.js'
+import buttonsCSS from '../../../app-stdlib/css/buttons2.css.js'
+import tooltipCSS from '../../../app-stdlib/css/tooltip.css.js'
+
+const cssStr = css`
+${colorsCSS}
+${buttonsCSS}
+${tooltipCSS}
+
+:host {
+  display: block;
+  max-width: 600px;
+}
+
+a {
+  color: var(--blue);
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.section {
+  margin-bottom: 30px;
+}
+
+.form-group {
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  padding: 10px 12px;
+  margin-bottom: 16px;
+}
+
+.form-group .section {
+  margin-bottom: 0;
+  padding: 0 10px 4px;
+}
+
+.form-group .section:not(:last-child) {
+  margin-bottom: 0;
+  padding-bottom: 16px;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.form-group .section > :first-child {
+  margin-top: 16px;
+}
+
+.form-group h2 {
+  margin: 0;
+  padding-bottom: 10px;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.message {
+  margin: 1em 0;
+  background: var(--bg-color--message);
+  padding: 10px;
+  border-radius: 2px;
+}
+
+.message > :first-child {
+  margin-top: 0;
+}
+
+.message > :last-child {
+  margin-bottom: 0;
+}
+
+input[type="text"], input[type="url"] {
+  height: 24px;
+  padding: 0 7px;
+  border-radius: 4px;
+  color: rgba(51, 51, 51, 0.95);
+  border: 1px solid #d9d9d9;
+  box-shadow: inset 0 1px 2px #0001;
+}
+
+textarea {
+  padding: 7px;
+  border-radius: 4px;
+  color: rgba(51, 51, 51, 0.95);
+  border: 1px solid #d9d9d9;
+  box-shadow: inset 0 1px 2px #0001;
+}
+
+input[type="text"]:focus,
+input[type="url"]:focus,
+textarea:focus {
+  outline: 0;
+  border: 1px solid rgba(41, 95, 203, 0.8);
+  box-shadow: 0 0 0 2px rgba(41, 95, 203, 0.2);
+}
+
+input[type="checkbox"] {
+  margin: 1px 7px 0 1px;
+}
+
+.adblock-settings-list {
+  margin-bottom: 10px;
+}
+
+.adblock-settings-list a {
+  color: gray;
+  cursor: pointer;
+}
+
+`
+export default cssStr

--- a/app/userland/settings/js/main.js
+++ b/app/userland/settings/js/main.js
@@ -3,6 +3,7 @@ import { classMap } from '../../app-stdlib/vendor/lit-element/lit-html/directive
 import * as QP from './lib/query-params.js'
 import css from '../css/main.css.js'
 import './views/general.js'
+import './views/adblock.js'
 import './views/devices.js'
 import './views/info.js'
 import './views/network.js'
@@ -62,6 +63,7 @@ class SettingsApp extends LitElement {
     }
     return html`
       ${item('general', 'fas fa-cog', 'General')}
+      ${item('adblock', 'fas fa-ban', 'Ad Blocking')}
       ${item('devices', 'fas fa-sync', 'Sync Devices')}
       <hr>
       ${item('general-logs', 'fas fa-clipboard-list', 'General Logs')}
@@ -77,6 +79,8 @@ class SettingsApp extends LitElement {
     switch (this.currentSubview) {
       case 'general':
         return html`<general-settings-view loadable></general-settings-view>`
+      case 'adblock':
+        return html`<adblock-settings-view loadable></adblock-settings-view>`
       case 'devices':
         return html`<devices-view loadable></devices-view>`
       case 'info':

--- a/app/userland/settings/js/views/adblock.js
+++ b/app/userland/settings/js/views/adblock.js
@@ -1,0 +1,116 @@
+import { LitElement, html, css } from '../../../app-stdlib/vendor/lit-element/lit-element.js'
+import viewCSS from '../../css/views/adblock.css.js'
+import * as toast from '../../../app-stdlib/js/com/toast.js'
+class AdblockSettingsView extends LitElement {
+  static get properties () {
+    return {
+    }
+  }
+
+  static get styles () {
+    return viewCSS
+  }
+
+  constructor () {
+    super()
+    this.settings = undefined
+    this.browserInfo = undefined
+  }
+
+  async load () {
+    // fetch data
+    this.browserInfo = await beaker.browser.getInfo()
+    this.settings = await beaker.browser.getSettings()
+    console.log('loaded', {
+      browserInfo: this.browserInfo,
+      settings: this.settings
+    })
+    this.requestUpdate()
+  }
+
+  // rendering
+  // =
+
+  render () {
+    if (!this.browserInfo) return html``
+    return html`
+      <link rel="stylesheet" href="beaker://assets/font-awesome.css">
+      <div class="form-group">
+        <h2>Filter Lists</h2>
+        ${this.renderFilterLists()}
+      </div>
+    `
+  }
+
+  renderFilterLists() {
+    return html`
+      <div class="section">
+        <div class="adblock-settings-list">
+          ${this.settings.adblock_lists.map((adblockList,i)=>{
+            return html`
+              <div class="checkbox-item">
+                <input type="checkbox"
+                  id="adblockList${i}"
+                  name="adblock-lists"
+                  value="${i}"
+                  ?checked="${adblockList.selected}"
+                  @change="${this.onAdblockListChange}"
+                >
+                <label for="adblockList${i}">
+                  ${adblockList.name} (${adblockList.url})
+                  ${this.settings.adblock_lists.length === 1 ? '' : html`
+                    <a @click="${()=>this.removeAdblockList(i)}" data-tooltip="Remove" title="Remove Adblock List">
+                      <span class="fas fa-fw fa-times"></span>
+                    </a>
+                  `}
+                </label>
+              </div>`
+            })
+          }
+        </div>
+        <form @submit=${this.onAddAdblockList}>
+          <input type="text" placeholder="Name" id="custom-adblock-list-name" required>
+          <input type="url" placeholder="URL" id="custom-adblock-list-url" required>
+          <button type="submit">Add</button>
+        </form>
+      </div>
+    `
+  }
+
+  // events
+  // =
+
+  onAdblockListChange (e) {
+    const index = e.target.value
+    if (e.target.checked) {
+      this.settings.adblock_lists[index].selected = true
+    } else {
+      delete this.settings.adblock_lists[index].selected
+    }
+    beaker.browser.setSetting('adblock_lists', this.settings.adblock_lists)
+    beaker.browser.updateAdblocker()
+    toast.create('Setting updated')
+    this.requestUpdate()
+  }
+
+  removeAdblockList (i) {
+    // decrement selected search engine so it points to the same one if the removed index is less than current one
+    this.settings.adblock_lists.splice(i, 1)
+    beaker.browser.setSetting('adblock_lists', this.settings.adblock_lists)
+    beaker.browser.updateAdblocker()
+    this.requestUpdate()
+  }
+
+  onAddAdblockList (e) {
+    e.preventDefault()
+    const name = this.shadowRoot.getElementById('custom-adblock-list-name')
+    const url  = this.shadowRoot.getElementById('custom-adblock-list-url')
+    this.settings.adblock_lists.push({name: name.value, url: url.value, selected: true})
+    beaker.browser.setSetting('adblock_lists', this.settings.adblock_lists)
+    beaker.browser.updateAdblocker()
+    name.value =""
+    url.value=""
+    this.requestUpdate()
+  }
+}
+customElements.define('adblock-settings-view', AdblockSettingsView)


### PR DESCRIPTION
Adds @cliqz/adblocker to check each `webRequest` against selected ad filter lists. [EasyList](https://easylist.to/easylist/easylist.txt) is activated by default and others default lists (from the [EasyList homepage](https://easylist.to/)) are available to activate ([EasyPrivacy](https://easylist.to/easylist/easyprivacy.txt), [EasyList Cookie List](https://easylist-downloads.adblockplus.org/easylist-cookie.txt), [Fanboy's Social Blocking List](https://easylist.to/easylist/fanboy-social.txt), [Fanboy's Annoyance List](https://easylist.to/easylist/fanboy-annoyance.txt), and [Adblock Warning Removal List](https://easylist-downloads.adblockplus.org/antiadblockfilters.txt)), plus more can be added from the Settings page.

Also adds a new tab to the Settings page where the filter lists can be activated/deactivated, removed, or added.