### PR TITLE
app, scripts: bump package.json for m1 support + sqlite

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -87,7 +87,7 @@
     "slugify": "^1.3.5",
     "speedometer": "^1.0.0",
     "split2": "^2.2.0",
-    "sqlite3": "^4.1.0",
+    "sqlite3": "^5.0.0",
     "stream-throttle": "^0.1.3",
     "streamx": "^2.6.0",
     "textextensions": "^2.5.0",

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -3,7 +3,7 @@
   "devDependencies": {
     "browserify": "^16.0.0",
     "electron": "11.0.0-beta.18",
-    "electron-builder": "^22.6.0",
+    "electron-builder": "^22.10.4",
     "electron-notarize": "^0.3.0",
     "eslint": "^4.5.0",
     "eslint-plugin-import": "^2.7.0",
@@ -114,6 +114,5 @@
   "bugs": {
     "url": "https://github.com/beakerbrowser/beaker/issues"
   },
-  "homepage": "https://beakerbrowser.com/",
-  "dependencies": {}
+  "homepage": "https://beakerbrowser.com/"
 }


### PR DESCRIPTION
- Bumps sqlite3 to 5.0.0 because the only breaking change is dropping support for Node <10 and knex is breaking on the sqlite4 peer dependency in the root.
- Bumps electron-builder to 22.10.4+, which is when M1 support was introduced. I expected more work here, but it does build without any further changes to the build config, and it does seem to run fine on my M1 Macbook Air?

<img width="1435" alt="image" src="https://user-images.githubusercontent.com/20846414/129119531-e97a3de6-1f5f-4b0c-8e81-2b6bb46f1197.png">

Cool, I guess. This doesn't solve the problem of "needing an M1 machine to build arm64 binaries", though, as far as I know.